### PR TITLE
Change the output of the Repositories with Releases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ Syntax:
 `./compute-stats.sh yaroslavafenkin,shlomomdahan 2024-12-01 2024-12-31`
 
 The Markdown report now includes a list of repositories that supplied a release during the chosen timeframe at the end of the report.
+
+The new output format for the list of repositories with releases is as follows:
+
+### Released plugins
+1. Released the [claim plugin](https://github.com/jenkinsci/jenkinsci/claim-plugin)
+2. Released the [email-ext plugin](https://github.com/jenkinsci/jenkinsci/email-ext-plugin)
+3. Released the [last-changes plugin](https://github.com/jenkinsci/jenkinsci/last-changes-plugin)
+4. Released the [pipeline-aggregator-view plugin](https://github.com/jenkinsci/jenkinsci/pipeline-aggregator-view-plugin)
+5. Released the [pollscm plugin](https://github.com/jenkinsci/jenkinsci/pollscm-plugin)
+6. Released the [port-allocator plugin](https://github.com/jenkinsci/jenkinsci/port-allocator-plugin)
+
+The repository names in the new format are sorted alphabetically to maintain consistency and readability.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The Markdown report now includes a list of repositories that supplied a release 
 The new output format for the list of repositories with releases is as follows:
 
 ### Released plugins
-1. Released the [claim plugin](https://github.com/jenkinsci/jenkinsci/claim-plugin)
-2. Released the [email-ext plugin](https://github.com/jenkinsci/jenkinsci/email-ext-plugin)
-3. Released the [last-changes plugin](https://github.com/jenkinsci/jenkinsci/last-changes-plugin)
-4. Released the [pipeline-aggregator-view plugin](https://github.com/jenkinsci/jenkinsci/pipeline-aggregator-view-plugin)
-5. Released the [pollscm plugin](https://github.com/jenkinsci/jenkinsci/pollscm-plugin)
-6. Released the [port-allocator plugin](https://github.com/jenkinsci/jenkinsci/port-allocator-plugin)
+1. Released the [claim plugin](https://github.com/jenkinsci/claim-plugin)
+2. Released the [email-ext plugin](https://github.com/jenkinsci/email-ext-plugin)
+3. Released the [last-changes plugin](https://github.com/jenkinsci/last-changes-plugin)
+4. Released the [pipeline-aggregator-view plugin](https://github.com/jenkinsci/pipeline-aggregator-view-plugin)
+5. Released the [pollscm plugin](https://github.com/jenkinsci/pollscm-plugin)
+6. Released the [port-allocator plugin](https://github.com/jenkinsci/port-allocator-plugin)
 
 The repository names in the new format are sorted alphabetically to maintain consistency and readability.

--- a/generate-report.sh
+++ b/generate-report.sh
@@ -236,7 +236,8 @@ generate_report() {
     # corresponds to the repository name.
     repo=$(echo "$line" | awk '{print $2}')
     # echo "$line Released the [$repo](https://github.com/$repo)" >> "$OUTPUT_MD"
-      echo "${line%% *} Released the [$repo](https://github.com/$repo)" >> "$OUTPUT_MD"
+    repo_name=${repo#*/}
+    echo "${line%% *} Released the [$repo_name](https://github.com/$repo)" >> "$OUTPUT_MD"
   done
 }
 

--- a/generate-report.sh
+++ b/generate-report.sh
@@ -201,11 +201,12 @@ generate_report() {
 
   # Include the list of repositories with releases
   echo "" >> "$OUTPUT_MD"
-  echo "## Repositories with Releases" >> "$OUTPUT_MD"
+  echo "### Released plugins" >> "$OUTPUT_MD"
   echo "" >> "$OUTPUT_MD"
-  while IFS= read -r repo; do
-    echo "- $repo" >> "$OUTPUT_MD"
-  done < "$REPOS_FILE"
+  sort "$REPOS_FILE" | nl -w1 -s'. ' | while IFS= read -r line; do
+    repo=$(echo "$line" | awk '{print $2}')
+    echo "$line Released the [$repo](https://github.com/$repo)" >> "$OUTPUT_MD"
+  done
 }
 
 # Run the report generation

--- a/generate-report.sh
+++ b/generate-report.sh
@@ -237,6 +237,7 @@ generate_report() {
     repo=$(echo "$line" | awk '{print $2}')
     # echo "$line Released the [$repo](https://github.com/$repo)" >> "$OUTPUT_MD"
     repo_name=${repo#*/}
+    repo_name=${repo_name//-plugin/ plugin}
     echo "${line%% *} Released the [$repo_name](https://github.com/$repo)" >> "$OUTPUT_MD"
   done
 }


### PR DESCRIPTION
Fixes #7

Update the `generate-report.sh` script to change the output format of the `Repositories with Releases` section.

* Change the section title from "## Repositories with Releases" to "### Released plugins".
* Modify the list format to use a numbered list and include the word "Released" and the repository name as a link.
* Sort the repository names alphabetically before generating the report.

Update the `README.md` to reflect the new output format.

* Add a description of the new output format.
* Mention that the repository names are sorted alphabetically.
* Include an example of the new output format.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/alpha-omega-stats/pull/8?shareId=d4370ff5-7b50-4603-8958-0d85151c7089).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README.md with a new "Released plugins" section.
	- Enhanced Markdown report output format to include numbered and sorted plugin repositories with GitHub links.

- **Improvements**
	- Modified the report generation process to improve repository list presentation.
	- Added checks for input JSON file existence and readability.
	- Implemented conditional sorting of repository names based on the `PRESERVE_ORDER` variable.
	- Improved output format with line numbers and structured presentation for each repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->