### PR TITLE
Include PRs updated within timeframe

### DIFF
--- a/compute-stats.sh
+++ b/compute-stats.sh
@@ -104,7 +104,7 @@ echo "Raw PR list:"
 echo "$PR_LIST"
 
 # Filter PRs by date and ensure repository is not null
-FILTERED_PR_LIST=$(echo "$PR_LIST" | jq "[.[] | select((.createdAt >= \"$START_DATE\" and .createdAt <= \"$END_DATE\") or (.updatedAt >= \"$START_DATE\" and .updatedAt <= \"$END_DATE\") and .repository != null)]")
+FILTERED_PR_LIST=$(echo "$PR_LIST" | jq "[.[] | select((.createdAt >= \"$START_DATE\" and .createdAt <= \"$END_DATE\" and .repository != null) or (.updatedAt >= \"$START_DATE\" and .updatedAt <= \"$END_DATE\" and .repository != null))]")
 echo "Filtered PR list:"
 echo "$FILTERED_PR_LIST"
 

--- a/compute-stats.sh
+++ b/compute-stats.sh
@@ -15,7 +15,7 @@ ORGS=("jenkinsci" "jenkins-infra")
 fetch_prs_for_org() {
   local org=$1
   local user=$2
-  gh pr list --state all --author "$user" --json number,title,createdAt,headRepository,state --search "org:$org created:$START_DATE..$END_DATE"
+  gh pr list --state all --author "$user" --json number,title,createdAt,updatedAt,headRepository,state --search "org:$org created:$START_DATE..$END_DATE updated:$START_DATE..$END_DATE"
 }
 
 # Function to fetch repositories with releases during the specified timeframe
@@ -104,7 +104,7 @@ echo "Raw PR list:"
 echo "$PR_LIST"
 
 # Filter PRs by date and ensure repository is not null
-FILTERED_PR_LIST=$(echo "$PR_LIST" | jq "[.[] | select(.createdAt >= \"$START_DATE\" and .createdAt <= \"$END_DATE\" and .repository != null)]")
+FILTERED_PR_LIST=$(echo "$PR_LIST" | jq "[.[] | select((.createdAt >= \"$START_DATE\" and .createdAt <= \"$END_DATE\") or (.updatedAt >= \"$START_DATE\" and .updatedAt <= \"$END_DATE\") and .repository != null)]")
 echo "Filtered PR list:"
 echo "$FILTERED_PR_LIST"
 

--- a/compute-stats.sh
+++ b/compute-stats.sh
@@ -9,7 +9,7 @@
 IFS=',' read -r -a USERS <<< "$1"  # Split the comma-separated list of users into an array
 START_DATE=$2
 END_DATE=$3
-ORGS=("jenkinsci" "jenkins-infra")
+ORGS=("jenkinsci" "jenkins-infra" "jenkins-docs")
 
 # Function to fetch PRs for a specific organization and user
 fetch_prs_for_org() {


### PR DESCRIPTION
Fixes #9

Modify `compute-stats.sh` to include PRs updated within the specified timeframe.

* Update the `fetch_prs_for_org` function to include `updated:$START_DATE..$END_DATE` in the `gh pr list` command.
* Update the `FILTERED_PR_LIST` variable to filter PRs based on both `createdAt` and `updatedAt` fields.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/alpha-omega-stats/pull/10?shareId=f4fa72f8-9e81-4cba-99ef-ed147bd1d3ee).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added "jenkins-docs" organization to PR tracking
	- Enhanced PR data collection to include updated timestamps
	- Expanded PR filtering to consider both creation and update dates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->