### PR TITLE
Add failing PRs sheet to Google Sheets

### DIFF
--- a/upload_to_sheets.py
+++ b/upload_to_sheets.py
@@ -180,10 +180,9 @@ if failing_prs:
         "horizontalAlignment": "CENTER"  # Center-align the text
     })
 
+    # Calculate failing PRs count (structure already validated above)
     failing_prs_count = 0
-    if failing_prs and isinstance(failing_prs, dict) and "data" in failing_prs and \
-        isinstance(failing_prs["data"], dict) and "search" in failing_prs["data"] and \
-        isinstance(failing_prs["data"]["search"], dict) and "nodes" in failing_prs["data"]["search"]:
+    if failing_prs and 'data' in failing_prs and 'search' in failing_prs['data'] and 'nodes' in failing_prs['data']['search']:
         failing_prs_count = len(failing_prs["data"]["search"]["nodes"])
 
 # Add a link to the "Failing PRs" sheet in the "Summary" sheet and include the count

--- a/upload_to_sheets.py
+++ b/upload_to_sheets.py
@@ -180,8 +180,14 @@ if failing_prs:
         "horizontalAlignment": "CENTER"  # Center-align the text
     })
 
-    # Add a link to the "Failing PRs" sheet in the "Summary" sheet
-    summary_data.append(["Failing PRs", "", "", "", "", f'=HYPERLINK("#gid={failing_prs_sheet.id}"; "Failing PRs")'])
+    failing_prs_count = 0
+    if failing_prs and isinstance(failing_prs, dict) and "data" in failing_prs and \
+        isinstance(failing_prs["data"], dict) and "search" in failing_prs["data"] and \
+        isinstance(failing_prs["data"]["search"], dict) and "nodes" in failing_prs["data"]["search"]:
+        failing_prs_count = len(failing_prs["data"]["search"]["nodes"])
+
+# Add a link to the "Failing PRs" sheet in the "Summary" sheet and  include the count
+summary_data.append(["Failing PRs", failing_prs_count, "", "", "", f'=HYPERLINK("#gid={failing_prs_sheet.id}"; "Failing PRs")'])
 summary_sheet.update(range_name="A1", values=summary_data, value_input_option="USER_ENTERED")
 
 # Format the summary sheet

--- a/upload_to_sheets.py
+++ b/upload_to_sheets.py
@@ -188,6 +188,11 @@ if failing_prs:
 
 # Add a link to the "Failing PRs" sheet in the "Summary" sheet and  include the count
 summary_data.append(["Failing PRs", failing_prs_count, "", "", "", f'=HYPERLINK("#gid={failing_prs_sheet.id}"; "Failing PRs")'])
+if failing_prs and 'failing_prs_sheet' in locals():
+    summary_data.append(["Failing PRs", failing_prs_count, "", "", "", f'=HYPERLINK("#gid={failing_prs_sheet.id}"; "Failing PRs")'])
+else:
+    summary_data.append(["Failing PRs", failing_prs_count, "", "", "", "No failing PRs data available"])
+
 summary_sheet.update(range_name="A1", values=summary_data, value_input_option="USER_ENTERED")
 
 # Format the summary sheet


### PR DESCRIPTION
Fixes #16

Add functionality to create a new sheet for failing PRs in `upload_to_sheets.py`.

* Load the `failing-prs.json` file and handle errors if the file is not found or cannot be decoded.
* Create a new sheet named "Failing PRs" in the Google Sheets document.
* Populate the "Failing PRs" sheet with the extracted data from `failing-prs.json`.
* Format the column titles in the "Failing PRs" sheet with bold font and light gray background.
* Add a link to the "Failing PRs" sheet in the "Summary" sheet.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/alpha-omega-stats/pull/17?shareId=901834b3-585a-460b-9522-118ac6e4a173).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated section in spreadsheets for tracking and displaying failing pull requests.
	- Automatically refreshes and formats the failing PR data, ensuring previous records are cleared.
	- Enhances navigation with hyperlinks linking the summary view to detailed failing PR information.
	- Implements robust error handling to inform users when data loading issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->