### PR TITLE
Add the status of the PR checks in the result JSON

### DIFF
--- a/report.json
+++ b/report.json
@@ -12,7 +12,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/51",
-    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available"
+    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 43,
@@ -27,7 +28,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-api-plugin/pull/43",
-    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available"
+    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 40,
@@ -42,7 +44,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/40",
-    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available"
+    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id\n\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 27,
@@ -57,7 +60,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/sqlserver-api-plugin/pull/27",
-    "description": "Hello sqlserver-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version"
+    "description": "Hello sqlserver-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 37,
@@ -72,7 +76,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/37",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 39,
@@ -88,7 +93,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/39",
-    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add plugins BOM\n    io.jenkins.tools.pluginmodernizer.AddPluginsBom\n    Add the Jenkins BOM to the dependenciesManagement section of the pom.xml\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add plugins BOM\n    io.jenkins.tools.pluginmodernizer.AddPluginsBom\n    Add the Jenkins BOM to the dependenciesManagement section of the pom.xml\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 38,
@@ -103,7 +109,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/38",
-    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "PENDING"
   },
   {
     "number": 37,
@@ -118,7 +125,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/37",
-    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    \nConfigure the Jenkins bill of material like explained on the tutorial)"
+    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    \nConfigure the Jenkins bill of material like explained on the tutorial)",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 36,
@@ -133,7 +141,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/36",
-    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade BOM version\n\n\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade parent version"
+    "description": "Hello gson-api developers!\nThis is a semi-automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade BOM version\n\n\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade parent version",
+    "checkStatus": "PENDING"
   },
   {
     "number": 39,
@@ -148,7 +157,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/asm-api-plugin/pull/39",
-    "description": "Applied the following recipes: io.jenkins.tools.pluginmodernizer.UpgradeBomVersion"
+    "description": "Applied the following recipes: io.jenkins.tools.pluginmodernizer.UpgradeBomVersion",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 12,
@@ -161,7 +171,8 @@
     "pluginName": "aio-tests",
     "labels": null,
     "url": "https://github.com/jenkinsci/aio-tests-plugin/pull/12",
-    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner"
+    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -174,7 +185,8 @@
     "pluginName": "agent-server-parameter",
     "labels": null,
     "url": "https://github.com/jenkinsci/agent-server-parameter-plugin/pull/4",
-    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner"
+    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 36,
@@ -187,7 +199,8 @@
     "pluginName": "NegotiateSSO",
     "labels": null,
     "url": "https://github.com/jenkinsci/negotiatesso-plugin/pull/36",
-    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner"
+    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 1640,
@@ -202,7 +215,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/git-plugin/pull/1640",
-    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner"
+    "description": "Applied the following recipes: AddPluginsBom, AddCodeOwner",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 213,
@@ -217,7 +231,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/213",
-    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 339,
@@ -232,7 +247,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/339",
-    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 99,
@@ -247,7 +263,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/99",
-    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 121,
@@ -262,7 +279,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/nunit-plugin/pull/121",
-    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 141,
@@ -277,7 +295,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/next-executions-plugin/pull/141",
-    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 115,
@@ -292,7 +311,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/login-theme-plugin/pull/115",
-    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 252,
@@ -307,7 +327,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/locale-plugin/pull/252",
-    "description": "Hello locale developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello locale developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 139,
@@ -322,7 +343,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/139",
-    "description": "Hello junit-attachments developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello junit-attachments developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 57,
@@ -337,7 +359,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/57",
-    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 48,
@@ -352,7 +375,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-api-plugin/pull/48",
-    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 44,
@@ -367,7 +391,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/44",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 44,
@@ -382,7 +407,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/44",
-    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 353,
@@ -397,7 +423,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/353",
-    "description": "Hello jobcacher developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello jobcacher developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 46,
@@ -412,7 +439,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/46",
-    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 92,
@@ -427,7 +455,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/92",
-    "description": "Hello flyway-runner developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello flyway-runner developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 107,
@@ -442,7 +471,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/107",
-    "description": "Hello flyway-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello flyway-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 131,
@@ -457,7 +487,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/file-operations-plugin/pull/131",
-    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 121,
@@ -472,7 +503,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/121",
-    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 103,
@@ -487,7 +519,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/103",
-    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 64,
@@ -502,7 +535,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/64",
-    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 3,
@@ -517,7 +551,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/3",
-    "description": "Hello commons-math3-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello commons-math3-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 30,
@@ -532,7 +567,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/30",
-    "description": "Hello byte-buddy-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello byte-buddy-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 228,
@@ -547,7 +583,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/228",
-    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 46,
@@ -562,7 +599,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/asm-api-plugin/pull/46",
-    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 17,
@@ -577,7 +615,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/17",
-    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 70,
@@ -592,7 +631,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/70",
-    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 257,
@@ -607,7 +647,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/ansible-plugin/pull/257",
-    "description": "Hello ansible developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello ansible developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 212,
@@ -622,7 +663,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/212",
-    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 338,
@@ -637,7 +679,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/338",
-    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 98,
@@ -652,7 +695,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/98",
-    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 120,
@@ -667,7 +711,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/nunit-plugin/pull/120",
-    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 140,
@@ -682,7 +727,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/next-executions-plugin/pull/140",
-    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 114,
@@ -697,7 +743,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/login-theme-plugin/pull/114",
-    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 251,
@@ -712,7 +759,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/locale-plugin/pull/251",
-    "description": "Hello locale developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello locale developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 138,
@@ -727,7 +775,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/138",
-    "description": "Hello junit-attachments developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello junit-attachments developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 56,
@@ -742,7 +791,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/56",
-    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 47,
@@ -757,7 +807,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-api-plugin/pull/47",
-    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 43,
@@ -772,7 +823,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/43",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 43,
@@ -787,7 +839,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/43",
-    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 45,
@@ -802,7 +855,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/45",
-    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 91,
@@ -817,7 +871,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/91",
-    "description": "Hello flyway-runner developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello flyway-runner developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 102,
@@ -832,7 +887,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/102",
-    "description": "Hello flyway-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello flyway-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 130,
@@ -847,7 +903,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/file-operations-plugin/pull/130",
-    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 120,
@@ -862,7 +919,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/120",
-    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 102,
@@ -877,7 +935,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/102",
-    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 63,
@@ -892,7 +951,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/63",
-    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 227,
@@ -907,7 +967,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/227",
-    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 45,
@@ -922,7 +983,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/asm-api-plugin/pull/45",
-    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 69,
@@ -937,7 +999,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/69",
-    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 256,
@@ -952,7 +1015,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/ansible-plugin/pull/256",
-    "description": "Hello ansible developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello ansible developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade parent version\n    io.jenkins.tools.pluginmodernizer.UpgradeParentVersion\n    Upgrade the parent version to latest available\n\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 224,
@@ -967,7 +1031,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/224",
-    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 347,
@@ -982,7 +1047,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/347",
-    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello postgresql-fingerprint-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 163,
@@ -997,7 +1063,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/163",
-    "description": "Hello pipeline-npm developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello pipeline-npm developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 107,
@@ -1012,7 +1079,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/107",
-    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello parameter-separator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 223,
@@ -1027,7 +1095,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/223",
-    "description": "Hello openshift-k8s-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello openshift-k8s-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 125,
@@ -1042,7 +1111,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/nunit-plugin/pull/125",
-    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello nunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 148,
@@ -1057,7 +1127,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/next-executions-plugin/pull/148",
-    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello next-executions developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 46,
@@ -1072,7 +1143,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/46",
-    "description": "Hello mariadb-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello mariadb-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 124,
@@ -1087,7 +1159,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/login-theme-plugin/pull/124",
-    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello login-theme developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 61,
@@ -1102,7 +1175,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/61",
-    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-path-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 51,
@@ -1117,7 +1191,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-api-plugin/pull/51",
-    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello json-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 47,
@@ -1132,7 +1207,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/47",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 58,
@@ -1147,7 +1223,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/58",
-    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello jobcacher-artifactory-storage developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 368,
@@ -1162,7 +1239,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/368",
-    "description": "Hello jobcacher developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello jobcacher developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 166,
@@ -1177,7 +1255,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/166",
-    "description": "Hello hidden-parameter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello hidden-parameter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 49,
@@ -1192,7 +1271,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/49",
-    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gson-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 197,
@@ -1207,7 +1287,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/197",
-    "description": "Hello gitlab-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello gitlab-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 138,
@@ -1222,7 +1303,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/file-operations-plugin/pull/138",
-    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello file-operations developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 127,
@@ -1237,7 +1319,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/127",
-    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extra-tool-installers developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 55,
@@ -1252,7 +1335,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/55",
-    "description": "Hello database-mariadb developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello database-mariadb developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 71,
@@ -1267,7 +1351,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/71",
-    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello coverage-badges-extension developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 8,
@@ -1282,7 +1367,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/8",
-    "description": "Hello commons-math3-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello commons-math3-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 42,
@@ -1297,7 +1383,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/42",
-    "description": "Hello byte-buddy-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello byte-buddy-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 243,
@@ -1312,7 +1399,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/243",
-    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello bitbucket-kubernetes-credentials developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 52,
@@ -1327,7 +1415,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/asm-api-plugin/pull/52",
-    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello asm-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 30,
@@ -1342,7 +1431,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/30",
-    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 81,
@@ -1357,7 +1447,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/81",
-    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-artifact-manager developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 499,
@@ -1370,7 +1461,8 @@
     "pluginName": "branch-api",
     "labels": null,
     "url": "https://github.com/jenkinsci/branch-api-plugin/pull/499",
-    "description": "Hello branch-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello branch-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 589,
@@ -1385,7 +1477,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/script-security-plugin/pull/589",
-    "description": "Hello script-security developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate pom to using jenkins.baseline property if bom is present\n    io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty\n    Migrate pom to using jenkins.baseline property if bom is present."
+    "description": "Hello script-security developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate pom to using jenkins.baseline property if bom is present\n    io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty\n    Migrate pom to using jenkins.baseline property if bom is present.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 239,
@@ -1398,7 +1491,8 @@
     "pluginName": "token-macro",
     "labels": null,
     "url": "https://github.com/jenkinsci/token-macro-plugin/pull/239",
-    "description": "Hello token-macro developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate pom to using jenkins.baseline property if bom is present\n    io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty\n    Migrate pom to using jenkins.baseline property if bom is present."
+    "description": "Hello token-macro developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate pom to using jenkins.baseline property if bom is present\n    io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty\n    Migrate pom to using jenkins.baseline property if bom is present.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 31,
@@ -1413,7 +1507,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/database-sqlserver-plugin/pull/31",
-    "description": "Hello database-sqlserver developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17."
+    "description": "Hello database-sqlserver developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 41,
@@ -1428,7 +1523,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/sqlserver-api-plugin/pull/41",
-    "description": "Hello sqlserver-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17."
+    "description": "Hello sqlserver-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 61,
@@ -1443,7 +1539,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/description-setter-plugin/pull/61",
-    "description": "Hello description-setter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello description-setter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 48,
@@ -1458,7 +1555,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/discard-old-build-plugin/pull/48",
-    "description": "Hello discard-old-build developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello discard-old-build developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 63,
@@ -1473,7 +1571,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/gitee-plugin/pull/63",
-    "description": "Hello gitee developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello gitee developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 60,
@@ -1486,7 +1585,8 @@
     "pluginName": "description-setter",
     "labels": null,
     "url": "https://github.com/jenkinsci/description-setter-plugin/pull/60",
-    "description": "Hello description-setter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello description-setter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 47,
@@ -1499,7 +1599,8 @@
     "pluginName": "discard-old-build",
     "labels": null,
     "url": "https://github.com/jenkinsci/discard-old-build-plugin/pull/47",
-    "description": "Hello discard-old-build developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello discard-old-build developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 8,
@@ -1512,7 +1613,8 @@
     "pluginName": "levo",
     "labels": null,
     "url": "https://github.com/jenkinsci/levo-plugin/pull/8",
-    "description": "Hello levo developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello levo developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 51,
@@ -1527,7 +1629,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/built-on-column-plugin/pull/51",
-    "description": "Hello built-on-column developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello built-on-column developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -1540,7 +1643,8 @@
     "pluginName": "levo",
     "labels": null,
     "url": "https://github.com/jenkinsci/levo-plugin/pull/7",
-    "description": "Hello levo developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello levo developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 13,
@@ -1553,7 +1657,8 @@
     "pluginName": "shared-library-version-override",
     "labels": null,
     "url": "https://github.com/jenkinsci/shared-library-version-override-plugin/pull/13",
-    "description": "Hello shared-library-version-override developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello shared-library-version-override developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 152,
@@ -1566,7 +1671,8 @@
     "pluginName": "xunit",
     "labels": null,
     "url": "https://github.com/jenkinsci/xunit-plugin/pull/152",
-    "description": "Hello xunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello xunit developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 269,
@@ -1579,7 +1685,8 @@
     "pluginName": "github-api",
     "labels": null,
     "url": "https://github.com/jenkinsci/github-api-plugin/pull/269",
-    "description": "Hello github-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Remove Release Drafter if CD is enabled\n    io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter\n    Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter"
+    "description": "Hello github-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Remove Release Drafter if CD is enabled\n    io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter\n    Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 268,
@@ -1592,7 +1699,8 @@
     "pluginName": "github-api",
     "labels": null,
     "url": "https://github.com/jenkinsci/github-api-plugin/pull/268",
-    "description": "Hello github-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Remove Release Drafter if CD is enabled\n    io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter\n    Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter"
+    "description": "Hello github-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Remove Release Drafter if CD is enabled\n    io.jenkins.tools.pluginmodernizer.RemoveReleaseDrafter\n    Remove Release Drafter if CD is enabled. See https://www.jenkins.io/doc/developer/publishing/releasing-cd/#configure-release-drafter",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 309,
@@ -1605,7 +1713,8 @@
     "pluginName": "ansicolor",
     "labels": null,
     "url": "https://github.com/jenkinsci/ansicolor-plugin/pull/309",
-    "description": "Hello ansicolor developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello ansicolor developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 156,
@@ -1618,7 +1727,8 @@
     "pluginName": "ant",
     "labels": null,
     "url": "https://github.com/jenkinsci/ant-plugin/pull/156",
-    "description": "Hello ant developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello ant developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 9,
@@ -1631,7 +1741,8 @@
     "pluginName": "r",
     "labels": null,
     "url": "https://github.com/jenkinsci/r-plugin/pull/9",
-    "description": "Hello r developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello r developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 244,
@@ -1646,7 +1757,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/durable-task-plugin/pull/244",
-    "description": "Hello durable-task developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello durable-task developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 148,
@@ -1661,7 +1773,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/pipeline-graph-analysis-plugin/pull/148",
-    "description": "Hello pipeline-graph-analysis developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello pipeline-graph-analysis developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 98,
@@ -1676,7 +1789,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/workflow-aggregator-plugin/pull/98",
-    "description": "Hello workflow-aggregator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello workflow-aggregator developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 133,
@@ -1691,7 +1805,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/pipeline-stage-step-plugin/pull/133",
-    "description": "Hello pipeline-stage-step developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello pipeline-stage-step developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 290,
@@ -1706,7 +1821,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/workflow-support-plugin/pull/290",
-    "description": "Hello workflow-support developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello workflow-support developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 367,
@@ -1721,7 +1837,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/workflow-api-plugin/pull/367",
-    "description": "Hello workflow-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello workflow-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 153,
@@ -1736,7 +1853,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/workflow-scm-step-plugin/pull/153",
-    "description": "Hello workflow-scm-step developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello workflow-scm-step developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 191,
@@ -1751,7 +1869,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/workflow-step-api-plugin/pull/191",
-    "description": "Hello workflow-step-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello workflow-step-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 211,
@@ -1764,7 +1883,8 @@
     "pluginName": "structs",
     "labels": null,
     "url": "https://github.com/jenkinsci/structs-plugin/pull/211",
-    "description": "Hello structs developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello structs developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 133,
@@ -1777,7 +1897,8 @@
     "pluginName": "build-timeout",
     "labels": null,
     "url": "https://github.com/jenkinsci/build-timeout-plugin/pull/133",
-    "description": "Hello build-timeout developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello build-timeout developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 296,
@@ -1792,7 +1913,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/metrics-plugin/pull/296",
-    "description": "Hello metrics developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello metrics developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 37,
@@ -1805,7 +1927,8 @@
     "pluginName": "openid",
     "labels": null,
     "url": "https://github.com/jenkinsci/openid-plugin/pull/37",
-    "description": "Hello openid developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version."
+    "description": "Hello openid developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest recommended core version and ensure the bom is matching the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to latest recommended core version and ensure the bom is matching the core version.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 235,
@@ -1820,7 +1943,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/235",
-    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17."
+    "description": "Hello skip-notifications-trait developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 113,
@@ -1835,7 +1959,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/113",
-    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello extension-filter developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 39,
@@ -1850,7 +1975,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/39",
-    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello artifactory-client-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 55,
@@ -1865,7 +1991,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/55",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 54,
@@ -1880,7 +2007,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/54",
-    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id"
+    "description": "Hello joda-time-api developers!\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available. Doesn't change the artifact id",
+    "checkStatus": "PENDING"
   },
   {
     "number": 141,
@@ -1893,7 +2021,8 @@
     "pluginName": "vsphere-cloud",
     "labels": null,
     "url": "https://github.com/jenkinsci/vsphere-cloud-plugin/pull/141",
-    "description": "Hello vsphere-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vsphere-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 150,
@@ -1906,7 +2035,8 @@
     "pluginName": "log-parser",
     "labels": null,
     "url": "https://github.com/jenkinsci/log-parser-plugin/pull/150",
-    "description": "Hello log-parser developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello log-parser developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 12,
@@ -1919,7 +2049,8 @@
     "pluginName": "results-cache",
     "labels": null,
     "url": "https://github.com/jenkinsci/results-cache-plugin/pull/12",
-    "description": "Hello results-cache developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello results-cache developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 11,
@@ -1932,7 +2063,8 @@
     "pluginName": "grypescanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/grypescanner-plugin/pull/11",
-    "description": "Hello grypescanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello grypescanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 12,
@@ -1945,7 +2077,8 @@
     "pluginName": "habitat",
     "labels": null,
     "url": "https://github.com/jenkinsci/habitat-plugin/pull/12",
-    "description": "Hello habitat developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello habitat developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 20,
@@ -1958,7 +2091,8 @@
     "pluginName": "hashicorp-vault-pipeline",
     "labels": null,
     "url": "https://github.com/jenkinsci/hashicorp-vault-pipeline-plugin/pull/20",
-    "description": "Hello hashicorp-vault-pipeline developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello hashicorp-vault-pipeline developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 92,
@@ -1971,7 +2105,8 @@
     "pluginName": "huaweicloud-ecs",
     "labels": null,
     "url": "https://github.com/jenkinsci/huaweicloud-ecs-plugin/pull/92",
-    "description": "Hello huaweicloud-ecs developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello huaweicloud-ecs developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 26,
@@ -1984,7 +2119,8 @@
     "pluginName": "proxmox",
     "labels": null,
     "url": "https://github.com/jenkinsci/proxmox-plugin/pull/26",
-    "description": "Hello proxmox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello proxmox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 18,
@@ -1997,7 +2133,8 @@
     "pluginName": "hudson-wsclean-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/wsclean-plugin/pull/18",
-    "description": "Hello hudson-wsclean-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello hudson-wsclean-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 130,
@@ -2010,7 +2147,8 @@
     "pluginName": "image-tag-parameter",
     "labels": null,
     "url": "https://github.com/jenkinsci/image-tag-parameter-plugin/pull/130",
-    "description": "Hello image-tag-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello image-tag-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 2,
@@ -2023,7 +2161,8 @@
     "pluginName": "immuniweb",
     "labels": null,
     "url": "https://github.com/jenkinsci/immuniweb-plugin/pull/2",
-    "description": "Hello immuniweb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello immuniweb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 11,
@@ -2036,7 +2175,8 @@
     "pluginName": "skip-cron-rebuild",
     "labels": null,
     "url": "https://github.com/jenkinsci/skip-cron-rebuild-plugin/pull/11",
-    "description": "Hello skip-cron-rebuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello skip-cron-rebuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 11,
@@ -2049,7 +2189,8 @@
     "pluginName": "instana",
     "labels": null,
     "url": "https://github.com/jenkinsci/instana-plugin/pull/11",
-    "description": "Hello instana developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello instana developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 24,
@@ -2062,7 +2203,8 @@
     "pluginName": "ironmq-notifier",
     "labels": null,
     "url": "https://github.com/jenkinsci/ironmq-notifier-plugin/pull/24",
-    "description": "Hello ironmq-notifier developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello ironmq-notifier developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 33,
@@ -2075,7 +2217,8 @@
     "pluginName": "jobcopy-builder",
     "labels": null,
     "url": "https://github.com/jenkinsci/jobcopy-builder-plugin/pull/33",
-    "description": "Hello jobcopy-builder developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello jobcopy-builder developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 35,
@@ -2088,7 +2231,8 @@
     "pluginName": "katalon",
     "labels": null,
     "url": "https://github.com/jenkinsci/katalon-plugin/pull/35",
-    "description": "Hello katalon developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello katalon developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 3,
@@ -2101,7 +2245,8 @@
     "pluginName": "kubesphere-token-auth",
     "labels": null,
     "url": "https://github.com/jenkinsci/kubesphere-token-auth-plugin/pull/3",
-    "description": "Hello kubesphere-token-auth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello kubesphere-token-auth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 6,
@@ -2114,7 +2259,8 @@
     "pluginName": "lacework-security-scanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/lacework-security-scanner-plugin/pull/6",
-    "description": "Hello lacework-security-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello lacework-security-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 9,
@@ -2127,7 +2273,8 @@
     "pluginName": "levo",
     "labels": null,
     "url": "https://github.com/jenkinsci/levo-plugin/pull/9",
-    "description": "Hello levo developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello levo developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 18,
@@ -2140,7 +2287,8 @@
     "pluginName": "llvm-cov",
     "labels": null,
     "url": "https://github.com/jenkinsci/llvm-cov-plugin/pull/18",
-    "description": "Hello llvm-cov developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello llvm-cov developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 11,
@@ -2153,7 +2301,8 @@
     "pluginName": "localization-support",
     "labels": null,
     "url": "https://github.com/jenkinsci/localization-support-plugin/pull/11",
-    "description": "Hello localization-support developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello localization-support developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 2,
@@ -2166,7 +2315,8 @@
     "pluginName": "log-command",
     "labels": null,
     "url": "https://github.com/jenkinsci/log-command-plugin/pull/2",
-    "description": "Hello log-command developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello log-command developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 149,
@@ -2179,7 +2329,8 @@
     "pluginName": "log-parser",
     "labels": null,
     "url": "https://github.com/jenkinsci/log-parser-plugin/pull/149",
-    "description": "Hello log-parser developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello log-parser developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 1,
@@ -2192,7 +2343,8 @@
     "pluginName": "logback-nats-appender",
     "labels": null,
     "url": "https://github.com/jenkinsci/logback-nats-appender-plugin/pull/1",
-    "description": "Hello logback-nats-appender developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata."
+    "description": "Hello logback-nats-appender developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 141,
@@ -2205,7 +2357,8 @@
     "pluginName": "macstadium-orka",
     "labels": null,
     "url": "https://github.com/jenkinsci/macstadium-orka-plugin/pull/141",
-    "description": "Hello macstadium-orka developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello macstadium-orka developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 8,
@@ -2218,7 +2371,8 @@
     "pluginName": "mergebase-sca",
     "labels": null,
     "url": "https://github.com/jenkinsci/mergebase-sca-plugin/pull/8",
-    "description": "Hello mergebase-sca developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello mergebase-sca developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 1,
@@ -2231,7 +2385,8 @@
     "pluginName": "metadefender",
     "labels": null,
     "url": "https://github.com/jenkinsci/metadefender-plugin/pull/1",
-    "description": "Hello metadefender developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello metadefender developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -2244,7 +2399,8 @@
     "pluginName": "metrics-datadog",
     "labels": null,
     "url": "https://github.com/jenkinsci/metrics-datadog-plugin/pull/15",
-    "description": "Hello metrics-datadog developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello metrics-datadog developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 10,
@@ -2257,7 +2413,8 @@
     "pluginName": "miniorange-saml-sp",
     "labels": null,
     "url": "https://github.com/jenkinsci/miniorange-saml-sp-plugin/pull/10",
-    "description": "Hello miniorange-saml-sp developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello miniorange-saml-sp developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 10,
@@ -2270,7 +2427,8 @@
     "pluginName": "modernstatus",
     "labels": null,
     "url": "https://github.com/jenkinsci/modernstatus-plugin/pull/10",
-    "description": "Hello modernstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello modernstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 1,
@@ -2283,7 +2441,8 @@
     "pluginName": "netdomain-labeler",
     "labels": null,
     "url": "https://github.com/jenkinsci/netdomain-labeler-plugin/pull/1",
-    "description": "Hello netdomain-labeler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello netdomain-labeler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 3,
@@ -2296,7 +2455,8 @@
     "pluginName": "neuro-cucumber",
     "labels": null,
     "url": "https://github.com/jenkinsci/neuro-cucumber-plugin/pull/3",
-    "description": "Hello neuro-cucumber developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello neuro-cucumber developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 71,
@@ -2309,7 +2469,8 @@
     "pluginName": "neuvector-vulnerability-scanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/neuvector-vulnerability-scanner-plugin/pull/71",
-    "description": "Hello neuvector-vulnerability-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello neuvector-vulnerability-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 6,
@@ -2322,7 +2483,8 @@
     "pluginName": "nuclei",
     "labels": null,
     "url": "https://github.com/jenkinsci/nuclei-plugin/pull/6",
-    "description": "Hello nuclei developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello nuclei developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -2335,7 +2497,8 @@
     "pluginName": "nutanix-calm",
     "labels": null,
     "url": "https://github.com/jenkinsci/nutanix-calm-plugin/pull/7",
-    "description": "Hello nutanix-calm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello nutanix-calm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 16,
@@ -2348,7 +2511,8 @@
     "pluginName": "nvm-wrapper",
     "labels": null,
     "url": "https://github.com/jenkinsci/nvm-wrapper-plugin/pull/16",
-    "description": "Hello nvm-wrapper developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello nvm-wrapper developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 15,
@@ -2361,7 +2525,8 @@
     "pluginName": "octoperf",
     "labels": null,
     "url": "https://github.com/jenkinsci/octoperf-plugin/pull/15",
-    "description": "Hello octoperf developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello octoperf developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 4,
@@ -2374,7 +2539,8 @@
     "pluginName": "opslevel",
     "labels": null,
     "url": "https://github.com/jenkinsci/opslevel-plugin/pull/4",
-    "description": "Hello opslevel developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello opslevel developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 16,
@@ -2387,7 +2553,8 @@
     "pluginName": "vmanager-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/vmanager-plugin/pull/16",
-    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions."
+    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 9,
@@ -2400,7 +2567,8 @@
     "pluginName": "osf-builder-suite-for-sfcc-run-job",
     "labels": null,
     "url": "https://github.com/jenkinsci/osf-builder-suite-for-sfcc-run-job-plugin/pull/9",
-    "description": "Hello osf-builder-suite-for-sfcc-run-job developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello osf-builder-suite-for-sfcc-run-job developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -2413,7 +2581,8 @@
     "pluginName": "ostorlab",
     "labels": null,
     "url": "https://github.com/jenkinsci/ostorlab-plugin/pull/15",
-    "description": "Hello ostorlab developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello ostorlab developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 2,
@@ -2426,7 +2595,8 @@
     "pluginName": "oversecured",
     "labels": null,
     "url": "https://github.com/jenkinsci/oversecured-plugin/pull/2",
-    "description": "Hello oversecured developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello oversecured developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -2439,7 +2609,8 @@
     "pluginName": "pipeline-global-lib-nexus",
     "labels": null,
     "url": "https://github.com/jenkinsci/pipeline-global-lib-nexus-plugin/pull/15",
-    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 6,
@@ -2452,7 +2623,8 @@
     "pluginName": "pipeline-keep-running-step",
     "labels": null,
     "url": "https://github.com/jenkinsci/pipeline-keep-running-step-plugin/pull/6",
-    "description": "Hello pipeline-keep-running-step developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello pipeline-keep-running-step developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 1,
@@ -2465,7 +2637,8 @@
     "pluginName": "portscanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/portscanner-plugin/pull/1",
-    "description": "Hello portscanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello portscanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 5,
@@ -2478,7 +2651,8 @@
     "pluginName": "probely-security",
     "labels": null,
     "url": "https://github.com/jenkinsci/probely-security-plugin/pull/5",
-    "description": "Hello probely-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello probely-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 25,
@@ -2491,7 +2665,8 @@
     "pluginName": "proxmox",
     "labels": null,
     "url": "https://github.com/jenkinsci/proxmox-plugin/pull/25",
-    "description": "Hello proxmox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello proxmox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -2504,7 +2679,8 @@
     "pluginName": "publish-over-dropbox",
     "labels": null,
     "url": "https://github.com/jenkinsci/publish-over-dropbox-plugin/pull/7",
-    "description": "Hello publish-over-dropbox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello publish-over-dropbox developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 9,
@@ -2517,7 +2693,8 @@
     "pluginName": "qiniu",
     "labels": null,
     "url": "https://github.com/jenkinsci/qiniu-plugin/pull/9",
-    "description": "Hello qiniu developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qiniu developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 50,
@@ -2530,7 +2707,8 @@
     "pluginName": "qualys-vm",
     "labels": null,
     "url": "https://github.com/jenkinsci/qualys-vm-plugin/pull/50",
-    "description": "Hello qualys-vm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qualys-vm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 36,
@@ -2543,7 +2721,8 @@
     "pluginName": "qualys-was",
     "labels": null,
     "url": "https://github.com/jenkinsci/qualys-was-plugin/pull/36",
-    "description": "Hello qualys-was developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qualys-was developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 11,
@@ -2556,7 +2735,8 @@
     "pluginName": "qy-wechat-notification",
     "labels": null,
     "url": "https://github.com/jenkinsci/qy-wechat-notification-plugin/pull/11",
-    "description": "Hello qy-wechat-notification developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qy-wechat-notification developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 13,
@@ -2569,7 +2749,8 @@
     "pluginName": "rabbitmq-publisher",
     "labels": null,
     "url": "https://github.com/jenkinsci/rabbitmq-publisher-plugin/pull/13",
-    "description": "Hello rabbitmq-publisher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello rabbitmq-publisher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 36,
@@ -2582,7 +2763,8 @@
     "pluginName": "rapid7-insightvm-container-assessment",
     "labels": null,
     "url": "https://github.com/jenkinsci/rapid7-insightvm-container-assessment-plugin/pull/36",
-    "description": "Hello rapid7-insightvm-container-assessment developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello rapid7-insightvm-container-assessment developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 3,
@@ -2595,7 +2777,8 @@
     "pluginName": "rapiddeploy-jenkins",
     "labels": null,
     "url": "https://github.com/jenkinsci/rapiddeploy-plugin/pull/3",
-    "description": "Hello rapiddeploy-jenkins developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello rapiddeploy-jenkins developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 4,
@@ -2608,7 +2791,8 @@
     "pluginName": "reliza-integration",
     "labels": null,
     "url": "https://github.com/jenkinsci/reliza-integration-plugin/pull/4",
-    "description": "Hello reliza-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello reliza-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 90,
@@ -2621,7 +2805,8 @@
     "pluginName": "repo",
     "labels": null,
     "url": "https://github.com/jenkinsci/repo-plugin/pull/90",
-    "description": "Hello repo developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello repo developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 67,
@@ -2634,7 +2819,8 @@
     "pluginName": "repository-connector",
     "labels": null,
     "url": "https://github.com/jenkinsci/repository-connector-plugin/pull/67",
-    "description": "Hello repository-connector developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello repository-connector developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -2647,7 +2833,8 @@
     "pluginName": "shutdown-queue",
     "labels": null,
     "url": "https://github.com/jenkinsci/shutdown-queue-plugin/pull/7",
-    "description": "Hello shutdown-queue developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this, a maintainer can replay the failed build by substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello shutdown-queue developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this, a maintainer can replay the failed build by substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 10,
@@ -2660,7 +2847,8 @@
     "pluginName": "requests",
     "labels": null,
     "url": "https://github.com/jenkinsci/requests-plugin/pull/10",
-    "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 11,
@@ -2673,7 +2861,8 @@
     "pluginName": "results-cache",
     "labels": null,
     "url": "https://github.com/jenkinsci/results-cache-plugin/pull/11",
-    "description": "Hello results-cache developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello results-cache developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 10,
@@ -2686,7 +2875,8 @@
     "pluginName": "rich-text-publisher-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/rich-text-publisher-plugin/pull/10",
-    "description": "Hello rich-text-publisher-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello rich-text-publisher-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 2,
@@ -2699,7 +2889,8 @@
     "pluginName": "secure-post-script",
     "labels": null,
     "url": "https://github.com/jenkinsci/secure-post-script-plugin/pull/2",
-    "description": "Hello secure-post-script developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello secure-post-script developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 3,
@@ -2712,7 +2903,8 @@
     "pluginName": "sematext",
     "labels": null,
     "url": "https://github.com/jenkinsci/sematext-plugin/pull/3",
-    "description": "Hello sematext developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sematext developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 42,
@@ -2727,7 +2919,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/shelve-project-plugin/pull/42",
-    "description": "Hello shelve-project-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello shelve-project-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 9,
@@ -2740,7 +2933,8 @@
     "pluginName": "shortcut-job",
     "labels": null,
     "url": "https://github.com/jenkinsci/shortcut-job-plugin/pull/9",
-    "description": "Hello shortcut-job developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello shortcut-job developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 6,
@@ -2753,7 +2947,8 @@
     "pluginName": "shutdown-queue",
     "labels": null,
     "url": "https://github.com/jenkinsci/shutdown-queue-plugin/pull/6",
-    "description": "Hello shutdown-queue developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello shutdown-queue developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 51,
@@ -2766,7 +2961,8 @@
     "pluginName": "skenai",
     "labels": null,
     "url": "https://github.com/jenkinsci/skenai-plugin/pull/51",
-    "description": "Hello skenai developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello skenai developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 10,
@@ -2779,7 +2975,8 @@
     "pluginName": "skip-cron-rebuild",
     "labels": null,
     "url": "https://github.com/jenkinsci/skip-cron-rebuild-plugin/pull/10",
-    "description": "Hello skip-cron-rebuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello skip-cron-rebuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 79,
@@ -2792,7 +2989,8 @@
     "pluginName": "solarized-theme",
     "labels": null,
     "url": "https://github.com/jenkinsci/solarized-theme-plugin/pull/79",
-    "description": "Hello solarized-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello solarized-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -2805,7 +3003,8 @@
     "pluginName": "split-admin",
     "labels": null,
     "url": "https://github.com/jenkinsci/split-admin-plugin/pull/4",
-    "description": "Hello split-admin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello split-admin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 1,
@@ -2818,7 +3017,8 @@
     "pluginName": "stackrox-container-image-scanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/stackrox-container-image-scanner-plugin/pull/1",
-    "description": "Hello stackrox-container-image-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello stackrox-container-image-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 189,
@@ -2831,7 +3031,8 @@
     "pluginName": "stash-pullrequest-builder",
     "labels": null,
     "url": "https://github.com/jenkinsci/stash-pullrequest-builder-plugin/pull/189",
-    "description": "Hello stash-pullrequest-builder developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello stash-pullrequest-builder developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 55,
@@ -2844,7 +3045,8 @@
     "pluginName": "statuspage-gating",
     "labels": null,
     "url": "https://github.com/jenkinsci/statuspage-gating-plugin/pull/55",
-    "description": "Hello statuspage-gating developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello statuspage-gating developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 5,
@@ -2857,7 +3059,8 @@
     "pluginName": "teams-webhook-trigger",
     "labels": null,
     "url": "https://github.com/jenkinsci/teams-webhook-trigger-plugin/pull/5",
-    "description": "Hello teams-webhook-trigger developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello teams-webhook-trigger developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -2870,7 +3073,8 @@
     "pluginName": "vmanager-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/vmanager-plugin/pull/15",
-    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 362,
@@ -2883,7 +3087,8 @@
     "pluginName": "tekton-client",
     "labels": null,
     "url": "https://github.com/jenkinsci/tekton-client-plugin/pull/362",
-    "description": "Hello tekton-client developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello tekton-client developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 5,
@@ -2896,7 +3101,8 @@
     "pluginName": "testcafe",
     "labels": null,
     "url": "https://github.com/jenkinsci/testcafe-plugin/pull/5",
-    "description": "Hello testcafe developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testcafe developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 22,
@@ -2909,7 +3115,8 @@
     "pluginName": "testflo-for-jira-test-management-automation",
     "labels": null,
     "url": "https://github.com/jenkinsci/testflo-for-jira-test-management-automation-plugin/pull/22",
-    "description": "Hello testflo-for-jira-test-management-automation developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testflo-for-jira-test-management-automation developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 20,
@@ -2922,7 +3129,8 @@
     "pluginName": "thycotic-devops-secrets-vault",
     "labels": null,
     "url": "https://github.com/jenkinsci/thycotic-devops-secrets-vault-plugin/pull/20",
-    "description": "Hello thycotic-devops-secrets-vault developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello thycotic-devops-secrets-vault developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 38,
@@ -2935,7 +3143,8 @@
     "pluginName": "thycotic-secret-server",
     "labels": null,
     "url": "https://github.com/jenkinsci/thycotic-secret-server-plugin/pull/38",
-    "description": "Hello thycotic-secret-server developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello thycotic-secret-server developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 108,
@@ -2948,7 +3157,8 @@
     "pluginName": "typetalk",
     "labels": null,
     "url": "https://github.com/jenkinsci/typetalk-plugin/pull/108",
-    "description": "Hello typetalk developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello typetalk developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 16,
@@ -2961,7 +3171,8 @@
     "pluginName": "uleska",
     "labels": null,
     "url": "https://github.com/jenkinsci/uleska-plugin/pull/16",
-    "description": "Hello uleska developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello uleska developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 22,
@@ -2974,7 +3185,8 @@
     "pluginName": "upload-build-to-sofy",
     "labels": null,
     "url": "https://github.com/jenkinsci/upload-build-to-sofy-plugin/pull/22",
-    "description": "Hello upload-build-to-sofy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello upload-build-to-sofy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 12,
@@ -2987,7 +3199,8 @@
     "pluginName": "upload-pgyer",
     "labels": null,
     "url": "https://github.com/jenkinsci/upload-pgyer-plugin/pull/12",
-    "description": "Hello upload-pgyer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello upload-pgyer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -3000,7 +3213,8 @@
     "pluginName": "vdoo-vision",
     "labels": null,
     "url": "https://github.com/jenkinsci/vdoo-vision-plugin/pull/4",
-    "description": "Hello vdoo-vision developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vdoo-vision developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 50,
@@ -3013,7 +3227,8 @@
     "pluginName": "visualexpert",
     "labels": null,
     "url": "https://github.com/jenkinsci/visualexpert-plugin/pull/50",
-    "description": "Hello visualexpert developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello visualexpert developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 83,
@@ -3026,7 +3241,8 @@
     "pluginName": "vstestrunner",
     "labels": null,
     "url": "https://github.com/jenkinsci/vstestrunner-plugin/pull/83",
-    "description": "Hello vstestrunner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vstestrunner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 3,
@@ -3039,7 +3255,8 @@
     "pluginName": "wetest-automation",
     "labels": null,
     "url": "https://github.com/jenkinsci/wetest-automation-plugin/pull/3",
-    "description": "Hello wetest-automation developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello wetest-automation developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 2,
@@ -3052,7 +3269,8 @@
     "pluginName": "wsap",
     "labels": null,
     "url": "https://github.com/jenkinsci/wsap-plugin/pull/2",
-    "description": "Hello wsap developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello wsap developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 161,
@@ -3065,7 +3283,8 @@
     "pluginName": "xcode-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/xcode-plugin/pull/161",
-    "description": "Hello xcode-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello xcode-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 27,
@@ -3078,7 +3297,8 @@
     "pluginName": "yet-another-build-visualizer",
     "labels": null,
     "url": "https://github.com/jenkinsci/yet-another-build-visualizer-plugin/pull/27",
-    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 49,
@@ -3091,7 +3311,8 @@
     "pluginName": "zap-pipeline",
     "labels": null,
     "url": "https://github.com/jenkinsci/zap-pipeline-plugin/pull/49",
-    "description": "Hello zap-pipeline developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello zap-pipeline developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 8,
@@ -3104,7 +3325,8 @@
     "pluginName": "zerobug",
     "labels": null,
     "url": "https://github.com/jenkinsci/zerobug-plugin/pull/8",
-    "description": "Hello zerobug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello zerobug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 20,
@@ -3117,7 +3339,8 @@
     "pluginName": "zoom",
     "labels": null,
     "url": "https://github.com/jenkinsci/zoom-plugin/pull/20",
-    "description": "Hello zoom developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello zoom developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 61,
@@ -3130,7 +3353,8 @@
     "pluginName": "zscaler-iac-scan",
     "labels": null,
     "url": "https://github.com/jenkinsci/zscaler-iac-scan-plugin/pull/61",
-    "description": "Hello zscaler-iac-scan developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello zscaler-iac-scan developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 191,
@@ -3143,7 +3367,8 @@
     "pluginName": "trilead-api",
     "labels": null,
     "url": "https://github.com/jenkinsci/trilead-api-plugin/pull/191",
-    "description": "Hello trilead-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello trilead-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 21,
@@ -3156,7 +3381,8 @@
     "pluginName": "onepassword-secrets",
     "labels": null,
     "url": "https://github.com/jenkinsci/onepassword-secrets-plugin/pull/21",
-    "description": "Hello onepassword-secrets developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello onepassword-secrets developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 11,
@@ -3169,7 +3395,8 @@
     "pluginName": "sonargraph-integration",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonargraph-integration-plugin/pull/11",
-    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 11,
@@ -3182,7 +3409,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/11",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 27,
@@ -3195,7 +3423,8 @@
     "pluginName": "jenkinsci-appspider-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/appspider-build-scanner-plugin/pull/27",
-    "description": "Hello jenkinsci-appspider-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello jenkinsci-appspider-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 20,
@@ -3208,7 +3437,8 @@
     "pluginName": "mqtt-notification-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/mqtt-notification-plugin/pull/20",
-    "description": "Hello mqtt-notification-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello mqtt-notification-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -3221,7 +3451,8 @@
     "pluginName": "pipeline-input-notification",
     "labels": null,
     "url": "https://github.com/jenkinsci/pipeline-input-notification-plugin/pull/4",
-    "description": "Hello pipeline-input-notification developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello pipeline-input-notification developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 114,
@@ -3234,7 +3465,8 @@
     "pluginName": "spotinst",
     "labels": null,
     "url": "https://github.com/jenkinsci/spotinst-plugin/pull/114",
-    "description": "Hello spotinst developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello spotinst developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -3247,7 +3479,8 @@
     "pluginName": "srcclr-installer",
     "labels": null,
     "url": "https://github.com/jenkinsci/srcclr-installer-plugin/pull/4",
-    "description": "Hello srcclr-installer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello srcclr-installer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 7,
@@ -3260,7 +3493,8 @@
     "pluginName": "stoplightio-report",
     "labels": null,
     "url": "https://github.com/jenkinsci/stoplightio-report-plugin/pull/7",
-    "description": "Hello stoplightio-report developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello stoplightio-report developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 56,
@@ -3273,7 +3507,8 @@
     "pluginName": "vectorcast-execution",
     "labels": null,
     "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/56",
-    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 3,
@@ -3286,7 +3521,8 @@
     "pluginName": "partyparrotstatus",
     "labels": null,
     "url": "https://github.com/jenkinsci/partyparrotstatus-plugin/pull/3",
-    "description": "Hello partyparrotstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello partyparrotstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 9,
@@ -3299,7 +3535,8 @@
     "pluginName": "qmetry-test-management",
     "labels": null,
     "url": "https://github.com/jenkinsci/qmetry-test-management-plugin/pull/9",
-    "description": "Hello qmetry-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello qmetry-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 12,
@@ -3312,7 +3549,8 @@
     "pluginName": "qtest",
     "labels": null,
     "url": "https://github.com/jenkinsci/qtest-plugin/pull/12",
-    "description": "Hello qtest developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello qtest developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 33,
@@ -3325,7 +3563,8 @@
     "pluginName": "redgate-sql-ci",
     "labels": null,
     "url": "https://github.com/jenkinsci/redgate-sql-ci-plugin/pull/33",
-    "description": "Hello redgate-sql-ci developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello redgate-sql-ci developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3338,7 +3577,8 @@
     "pluginName": "runscope",
     "labels": null,
     "url": "https://github.com/jenkinsci/runscope-plugin/pull/6",
-    "description": "Hello runscope developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello runscope developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 5,
@@ -3351,7 +3591,8 @@
     "pluginName": "safe-batch-environment-filter",
     "labels": null,
     "url": "https://github.com/jenkinsci/safe-batch-environment-filter-plugin/pull/5",
-    "description": "Hello safe-batch-environment-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello safe-batch-environment-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 2,
@@ -3364,7 +3605,8 @@
     "pluginName": "sensedia-api-platform",
     "labels": null,
     "url": "https://github.com/jenkinsci/sensedia-api-platform-plugin/pull/2",
-    "description": "Hello sensedia-api-platform developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello sensedia-api-platform developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 3,
@@ -3377,7 +3619,8 @@
     "pluginName": "signal-killer",
     "labels": null,
     "url": "https://github.com/jenkinsci/signal-killer/pull/3",
-    "description": "Hello signal-killer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello signal-killer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 22,
@@ -3390,7 +3633,8 @@
     "pluginName": "sitemonitor",
     "labels": null,
     "url": "https://github.com/jenkinsci/sitemonitor-plugin/pull/22",
-    "description": "Hello sitemonitor developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello sitemonitor developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 22,
@@ -3403,7 +3647,8 @@
     "pluginName": "sonar",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonarqube-plugin/pull/22",
-    "description": "Hello sonar developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello sonar developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 10,
@@ -3416,7 +3661,8 @@
     "pluginName": "sonargraph-integration",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonargraph-integration-plugin/pull/10",
-    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 2,
@@ -3429,7 +3675,8 @@
     "pluginName": "sonarqube-generic-coverage",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonarqube-generic-coverage-plugin/pull/2",
-    "description": "Hello sonarqube-generic-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello sonarqube-generic-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 113,
@@ -3442,7 +3689,8 @@
     "pluginName": "spotinst",
     "labels": null,
     "url": "https://github.com/jenkinsci/spotinst-plugin/pull/113",
-    "description": "Hello spotinst developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello spotinst developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 3,
@@ -3455,7 +3703,8 @@
     "pluginName": "srcclr-installer",
     "labels": null,
     "url": "https://github.com/jenkinsci/srcclr-installer-plugin/pull/3",
-    "description": "Hello srcclr-installer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello srcclr-installer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3468,7 +3717,8 @@
     "pluginName": "stoplightio-report",
     "labels": null,
     "url": "https://github.com/jenkinsci/stoplightio-report-plugin/pull/6",
-    "description": "Hello stoplightio-report developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello stoplightio-report developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 11,
@@ -3481,7 +3731,8 @@
     "pluginName": "testingbot",
     "labels": null,
     "url": "https://github.com/jenkinsci/testingbot-plugin/pull/11",
-    "description": "Hello testingbot developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello testingbot developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 14,
@@ -3494,7 +3745,8 @@
     "pluginName": "testodyssey-execution",
     "labels": null,
     "url": "https://github.com/jenkinsci/testodyssey-execution-plugin/pull/14",
-    "description": "Hello testodyssey-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello testodyssey-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 7,
@@ -3507,7 +3759,8 @@
     "pluginName": "testquality-updater",
     "labels": null,
     "url": "https://github.com/jenkinsci/testquality-updater-plugin/pull/7",
-    "description": "Hello testquality-updater developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello testquality-updater developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 9,
@@ -3520,7 +3773,8 @@
     "pluginName": "testsigma",
     "labels": null,
     "url": "https://github.com/jenkinsci/testsigma-plugin/pull/9",
-    "description": "Hello testsigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello testsigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 29,
@@ -3533,7 +3787,8 @@
     "pluginName": "unity3d-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/unity3d-plugin/pull/29",
-    "description": "Hello unity3d-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello unity3d-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -3546,7 +3801,8 @@
     "pluginName": "vagrant",
     "labels": null,
     "url": "https://github.com/jenkinsci/vagrant-plugin/pull/15",
-    "description": "Hello vagrant developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello vagrant developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 20,
@@ -3559,7 +3815,8 @@
     "pluginName": "vectorcast-coverage",
     "labels": null,
     "url": "https://github.com/jenkinsci/vectorcast-coverage-plugin/pull/20",
-    "description": "Hello vectorcast-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello vectorcast-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 7,
@@ -3572,7 +3829,8 @@
     "pluginName": "visualworks-store",
     "labels": null,
     "url": "https://github.com/jenkinsci/visualworks-store-plugin/pull/7",
-    "description": "Hello visualworks-store developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nThe checks are failing\nYour current Jenkinsfile is targeting JDK8 and JDK11. This PR will only work with JDK11+.\nWe supplied a modified Jenkinsfile with the other changes, but it won't be used until you replay the checks with it.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello visualworks-store developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nThe checks are failing\nYour current Jenkinsfile is targeting JDK8 and JDK11. This PR will only work with JDK11+.\nWe supplied a modified Jenkinsfile with the other changes, but it won't be used until you replay the checks with it.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 13,
@@ -3585,7 +3843,8 @@
     "pluginName": "vmanager-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/vmanager-plugin/pull/13",
-    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 8,
@@ -3598,7 +3857,8 @@
     "pluginName": "vncviewer",
     "labels": null,
     "url": "https://github.com/jenkinsci/vncviewer-plugin/pull/8",
-    "description": "Hello vncviewer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello vncviewer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 2,
@@ -3611,7 +3871,8 @@
     "pluginName": "webhook-eventsource",
     "labels": null,
     "url": "https://github.com/jenkinsci/webhook-eventsource-plugin/pull/2",
-    "description": "Hello webhook-eventsource developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello webhook-eventsource developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 2,
@@ -3624,7 +3885,8 @@
     "pluginName": "webload",
     "labels": null,
     "url": "https://github.com/jenkinsci/webload-plugin/pull/2",
-    "description": "Hello webload developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello webload developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3637,7 +3899,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/6",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 5,
@@ -3650,7 +3913,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/5",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -3663,7 +3927,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/4",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -3678,7 +3943,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jsoup-plugin/pull/4",
-    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 3,
@@ -3691,7 +3957,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/3",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 11 and 17.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21."
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 11 and 17.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 8,
@@ -3704,7 +3971,8 @@
     "pluginName": "report-info",
     "labels": null,
     "url": "https://github.com/jenkinsci/report-info-plugin/pull/8",
-    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add XML declaration to Jelly files and create index.jelly if it doesn't exist\n    io.jenkins.tools.pluginmodernizer.FixJellyIssues\n    Ensure the XML declaration `\u003c?jelly escape-by-default='true'?\u003e` is present in all `.jelly` files and create index.jelly if it doesn't exist.\n\nTesting\nThe checks should go green after #5 is merged."
+    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add XML declaration to Jelly files and create index.jelly if it doesn't exist\n    io.jenkins.tools.pluginmodernizer.FixJellyIssues\n    Ensure the XML declaration `\u003c?jelly escape-by-default='true'?\u003e` is present in all `.jelly` files and create index.jelly if it doesn't exist.\n\nTesting\nThe checks should go green after #5 is merged.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 7,
@@ -3717,7 +3985,8 @@
     "pluginName": "report-info",
     "labels": null,
     "url": "https://github.com/jenkinsci/report-info-plugin/pull/7",
-    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nTesting\nThe checks should go green after #5 is merged.\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin. By automating this process with Dependabot, you open the door to a host of advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures your plugin stays at the cutting edge by promptly updating it with the latest features and improvements from upstream libraries.\n\n\nStrengthen Security: Staying current with dependency updates is critical for security. Dependabot automatically flags and updates any vulnerable dependencies, helping to shield your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating. Dependabot automatically submits pull requests for new releases, allowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates enhance both performance and compatibility with other plugins and the Jenkins core, ensuring a smooth experience for your users.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, while it takes care of keeping everything up-to-date under the hood.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with the best practices in the industry. We invite you to test these updates and embrace a maintenance workflow that is efficient and secure.\nYour insights and feedback are invaluable to us, and we'll be here to support you through this transition as needed."
+    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nTesting\nThe checks should go green after #5 is merged.\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin. By automating this process with Dependabot, you open the door to a host of advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures your plugin stays at the cutting edge by promptly updating it with the latest features and improvements from upstream libraries.\n\n\nStrengthen Security: Staying current with dependency updates is critical for security. Dependabot automatically flags and updates any vulnerable dependencies, helping to shield your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating. Dependabot automatically submits pull requests for new releases, allowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates enhance both performance and compatibility with other plugins and the Jenkins core, ensuring a smooth experience for your users.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, while it takes care of keeping everything up-to-date under the hood.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with the best practices in the industry. We invite you to test these updates and embrace a maintenance workflow that is efficient and secure.\nYour insights and feedback are invaluable to us, and we'll be here to support you through this transition as needed.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 6,
@@ -3730,7 +3999,8 @@
     "pluginName": "report-info",
     "labels": null,
     "url": "https://github.com/jenkinsci/report-info-plugin/pull/6",
-    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nThe checks should go green after #5 is merged."
+    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nThe checks should go green after #5 is merged.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 5,
@@ -3743,7 +4013,8 @@
     "pluginName": "report-info",
     "labels": null,
     "url": "https://github.com/jenkinsci/report-info-plugin/pull/5",
-    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nThanks for taking the time to review this PR. 🙏"
+    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nThanks for taking the time to review this PR. 🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -3756,7 +4027,8 @@
     "pluginName": "wavefront",
     "labels": null,
     "url": "https://github.com/jenkinsci/wavefront-plugin/pull/4",
-    "description": "Hello wavefront developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello wavefront developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3769,7 +4041,8 @@
     "pluginName": "environment-filter-utils",
     "labels": null,
     "url": "https://github.com/jenkinsci/environment-filter-utils-plugin/pull/6",
-    "description": "Hello environment-filter-utils developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello environment-filter-utils developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 12,
@@ -3782,7 +4055,8 @@
     "pluginName": "appdynamics-dashboard",
     "labels": null,
     "url": "https://github.com/jenkinsci/appdynamics-plugin/pull/12",
-    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 11,
@@ -3795,7 +4069,8 @@
     "pluginName": "appdynamics-dashboard",
     "labels": null,
     "url": "https://github.com/jenkinsci/appdynamics-plugin/pull/11",
-    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin. By automating this process with Dependabot, you open the door to a host of advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures your plugin stays at the cutting edge by promptly updating it with the latest features and improvements from upstream libraries.\n\n\nStrengthen Security: Staying current with dependency updates is critical for security. Dependabot automatically flags and updates any vulnerable dependencies, helping to shield your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating. Dependabot automatically submits pull requests for new releases, allowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates enhance both performance and compatibility with other plugins and the Jenkins core, ensuring a smooth experience for your users.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, while it takes care of keeping everything up-to-date under the hood.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with the best practices in the industry. We invite you to test these updates and embrace a maintenance workflow that is efficient and secure.\nYour insights and feedback are invaluable to us, and we'll be here to support you through this transition as needed."
+    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin. By automating this process with Dependabot, you open the door to a host of advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures your plugin stays at the cutting edge by promptly updating it with the latest features and improvements from upstream libraries.\n\n\nStrengthen Security: Staying current with dependency updates is critical for security. Dependabot automatically flags and updates any vulnerable dependencies, helping to shield your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating. Dependabot automatically submits pull requests for new releases, allowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates enhance both performance and compatibility with other plugins and the Jenkins core, ensuring a smooth experience for your users.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, while it takes care of keeping everything up-to-date under the hood.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with the best practices in the industry. We invite you to test these updates and embrace a maintenance workflow that is efficient and secure.\nYour insights and feedback are invaluable to us, and we'll be here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 10,
@@ -3808,7 +4083,8 @@
     "pluginName": "testingbot",
     "labels": null,
     "url": "https://github.com/jenkinsci/testingbot-plugin/pull/10",
-    "description": "Hello testingbot developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testingbot developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 13,
@@ -3821,7 +4097,8 @@
     "pluginName": "testodyssey-execution",
     "labels": null,
     "url": "https://github.com/jenkinsci/testodyssey-execution-plugin/pull/13",
-    "description": "Hello testodyssey-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testodyssey-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3834,7 +4111,8 @@
     "pluginName": "testquality-updater",
     "labels": null,
     "url": "https://github.com/jenkinsci/testquality-updater-plugin/pull/6",
-    "description": "Hello testquality-updater developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testquality-updater developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 8,
@@ -3847,7 +4125,8 @@
     "pluginName": "testsigma",
     "labels": null,
     "url": "https://github.com/jenkinsci/testsigma-plugin/pull/8",
-    "description": "Hello testsigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello testsigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 28,
@@ -3860,7 +4139,8 @@
     "pluginName": "unity3d-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/unity3d-plugin/pull/28",
-    "description": "Hello unity3d-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello unity3d-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 14,
@@ -3873,7 +4153,8 @@
     "pluginName": "vagrant",
     "labels": null,
     "url": "https://github.com/jenkinsci/vagrant-plugin/pull/14",
-    "description": "Hello vagrant developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vagrant developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 55,
@@ -3886,7 +4167,8 @@
     "pluginName": "vectorcast-execution",
     "labels": null,
     "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/55",
-    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 15,
@@ -3899,7 +4181,8 @@
     "pluginName": "view26",
     "labels": null,
     "url": "https://github.com/jenkinsci/view26-plugin/pull/15",
-    "description": "Hello view26 developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello view26 developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 6,
@@ -3912,7 +4195,8 @@
     "pluginName": "visualworks-store",
     "labels": null,
     "url": "https://github.com/jenkinsci/visualworks-store-plugin/pull/6",
-    "description": "Hello visualworks-store developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello visualworks-store developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 12,
@@ -3925,7 +4209,8 @@
     "pluginName": "vmanager-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/vmanager-plugin/pull/12",
-    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vmanager-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 7,
@@ -3938,7 +4223,8 @@
     "pluginName": "vncviewer",
     "labels": null,
     "url": "https://github.com/jenkinsci/vncviewer-plugin/pull/7",
-    "description": "Hello vncviewer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello vncviewer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 3,
@@ -3951,7 +4237,8 @@
     "pluginName": "wavefront",
     "labels": null,
     "url": "https://github.com/jenkinsci/wavefront-plugin/pull/3",
-    "description": "Hello wavefront developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello wavefront developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 1,
@@ -3964,7 +4251,8 @@
     "pluginName": "webhook-eventsource",
     "labels": null,
     "url": "https://github.com/jenkinsci/webhook-eventsource-plugin/pull/1",
-    "description": "Hello webhook-eventsource developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello webhook-eventsource developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 1,
@@ -3977,7 +4265,8 @@
     "pluginName": "webload",
     "labels": null,
     "url": "https://github.com/jenkinsci/webload-plugin/pull/1",
-    "description": "Hello webload developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello webload developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 10,
@@ -3990,7 +4279,8 @@
     "pluginName": "wso2id-oauth",
     "labels": null,
     "url": "https://github.com/jenkinsci/wso2id-oauth-plugin/pull/10",
-    "description": "Hello wso2id-oauth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello wso2id-oauth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 10,
@@ -4003,7 +4293,8 @@
     "pluginName": "appdynamics-dashboard",
     "labels": null,
     "url": "https://github.com/jenkinsci/appdynamics-plugin/pull/10",
-    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nStarting with the Jenkins 2.463 weekly release, Jenkins now requires Java 17 or newer.\nThe first Long-Term Support (LTS) release requiring Java 17 or newer (version 2.479.x) was released at the end of October 2024.\nThe Jenkins core team strongly recommends that all users adopt either Java 17 or Java 21.\nThe adoption of Java 17 has almost surpassed that of Java 11, and the usage of Java 21 is rapidly increasing.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nWhile this PR does not automatically make your plugin compatible with Java 17 or 21, it represents the first step towards a new era. Your plugin will be built and tested within the Jenkins infrastructure using Java 17 and 21.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21."
+    "description": "Hello appdynamics-dashboard developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nStarting with the Jenkins 2.463 weekly release, Jenkins now requires Java 17 or newer.\nThe first Long-Term Support (LTS) release requiring Java 17 or newer (version 2.479.x) was released at the end of October 2024.\nThe Jenkins core team strongly recommends that all users adopt either Java 17 or Java 21.\nThe adoption of Java 17 has almost surpassed that of Java 11, and the usage of Java 21 is rapidly increasing.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nWhile this PR does not automatically make your plugin compatible with Java 17 or 21, it represents the first step towards a new era. Your plugin will be built and tested within the Jenkins infrastructure using Java 17 and 21.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 1,
@@ -4016,7 +4307,8 @@
     "pluginName": "sonarqube-generic-coverage",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonarqube-generic-coverage-plugin/pull/1",
-    "description": "Hello sonarqube-generic-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sonarqube-generic-coverage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 9,
@@ -4029,7 +4321,8 @@
     "pluginName": "sonargraph-integration",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonargraph-integration-plugin/pull/9",
-    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sonargraph-integration developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 21,
@@ -4042,7 +4335,8 @@
     "pluginName": "sonar",
     "labels": null,
     "url": "https://github.com/jenkinsci/sonarqube-plugin/pull/21",
-    "description": "Hello sonar developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sonar developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 21,
@@ -4055,7 +4349,8 @@
     "pluginName": "sitemonitor",
     "labels": null,
     "url": "https://github.com/jenkinsci/sitemonitor-plugin/pull/21",
-    "description": "Hello sitemonitor developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sitemonitor developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 2,
@@ -4068,7 +4363,8 @@
     "pluginName": "signal-killer",
     "labels": null,
     "url": "https://github.com/jenkinsci/signal-killer/pull/2",
-    "description": "Hello signal-killer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello signal-killer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 1,
@@ -4081,7 +4377,8 @@
     "pluginName": "sensedia-api-platform",
     "labels": null,
     "url": "https://github.com/jenkinsci/sensedia-api-platform-plugin/pull/1",
-    "description": "Hello sensedia-api-platform developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello sensedia-api-platform developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 2,
@@ -4094,7 +4391,8 @@
     "pluginName": "send-stacktrace-to-eclipse-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/send-stacktrace-to-eclipse-plugin/pull/2",
-    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello send-stacktrace-to-eclipse-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -4107,7 +4405,8 @@
     "pluginName": "safe-batch-environment-filter",
     "labels": null,
     "url": "https://github.com/jenkinsci/safe-batch-environment-filter-plugin/pull/4",
-    "description": "Hello safe-batch-environment-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello safe-batch-environment-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 5,
@@ -4120,7 +4419,8 @@
     "pluginName": "runscope",
     "labels": null,
     "url": "https://github.com/jenkinsci/runscope-plugin/pull/5",
-    "description": "Hello runscope developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello runscope developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -4133,7 +4433,8 @@
     "pluginName": "report-info",
     "labels": null,
     "url": "https://github.com/jenkinsci/report-info-plugin/pull/4",
-    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello report-info developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 32,
@@ -4146,7 +4447,8 @@
     "pluginName": "redgate-sql-ci",
     "labels": null,
     "url": "https://github.com/jenkinsci/redgate-sql-ci-plugin/pull/32",
-    "description": "Hello redgate-sql-ci developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello redgate-sql-ci developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 11,
@@ -4159,7 +4461,8 @@
     "pluginName": "qtest",
     "labels": null,
     "url": "https://github.com/jenkinsci/qtest-plugin/pull/11",
-    "description": "Hello qtest developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qtest developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 8,
@@ -4172,7 +4475,8 @@
     "pluginName": "qmetry-test-management",
     "labels": null,
     "url": "https://github.com/jenkinsci/qmetry-test-management-plugin/pull/8",
-    "description": "Hello qmetry-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qmetry-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 25,
@@ -4185,7 +4489,8 @@
     "pluginName": "qmetry-for-jira-test-management",
     "labels": null,
     "url": "https://github.com/jenkinsci/qmetry-for-jira-test-management-plugin/pull/25",
-    "description": "Hello qmetry-for-jira-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello qmetry-for-jira-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 2,
@@ -4198,7 +4503,8 @@
     "pluginName": "partyparrotstatus",
     "labels": null,
     "url": "https://github.com/jenkinsci/partyparrotstatus-plugin/pull/2",
-    "description": "Hello partyparrotstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello partyparrotstatus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 9,
@@ -4211,7 +4517,8 @@
     "pluginName": "parallels-desktop",
     "labels": null,
     "url": "https://github.com/jenkinsci/parallels-desktop-plugin/pull/9",
-    "description": "Hello parallels-desktop developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello parallels-desktop developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -4224,7 +4531,8 @@
     "pluginName": "mttr",
     "labels": null,
     "url": "https://github.com/jenkinsci/mttr-plugin/pull/4",
-    "description": "Hello mttr developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello mttr developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 4,
@@ -4237,7 +4545,8 @@
     "pluginName": "msginject",
     "labels": null,
     "url": "https://github.com/jenkinsci/msginject-plugin/pull/4",
-    "description": "Hello msginject developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello msginject developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 19,
@@ -4250,7 +4559,8 @@
     "pluginName": "mqtt-notification-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/mqtt-notification-plugin/pull/19",
-    "description": "Hello mqtt-notification-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello mqtt-notification-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 10,
@@ -4263,7 +4573,8 @@
     "pluginName": "mission-control-view",
     "labels": null,
     "url": "https://github.com/jenkinsci/mission-control-view-plugin/pull/10",
-    "description": "Hello mission-control-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello mission-control-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 5,
@@ -4276,7 +4587,8 @@
     "pluginName": "metrics-graphite",
     "labels": null,
     "url": "https://github.com/jenkinsci/metrics-graphite-plugin/pull/5",
-    "description": "Hello metrics-graphite developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello metrics-graphite developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 73,
@@ -4289,7 +4601,8 @@
     "pluginName": "lucene-search",
     "labels": null,
     "url": "https://github.com/jenkinsci/lucene-search-plugin/pull/73",
-    "description": "Hello lucene-search developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello lucene-search developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -4302,7 +4615,8 @@
     "pluginName": "loadcomplete",
     "labels": null,
     "url": "https://github.com/jenkinsci/loadcomplete-plugin/pull/7",
-    "description": "Hello loadcomplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello loadcomplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 5,
@@ -4315,7 +4629,8 @@
     "pluginName": "lifx-notifier",
     "labels": null,
     "url": "https://github.com/jenkinsci/lifx-notifier-plugin/pull/5",
-    "description": "Hello lifx-notifier developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello lifx-notifier developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 17,
@@ -4328,7 +4643,8 @@
     "pluginName": "kiuwanJenkinsPlugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/kiuwan-plugin/pull/17",
-    "description": "Hello kiuwanJenkinsPlugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello kiuwanJenkinsPlugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 54,
@@ -4341,7 +4657,8 @@
     "pluginName": "jenkinswalldisplay",
     "labels": null,
     "url": "https://github.com/jenkinsci/walldisplay-plugin/pull/54",
-    "description": "Hello jenkinswalldisplay developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello jenkinswalldisplay developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 26,
@@ -4354,7 +4671,8 @@
     "pluginName": "jenkinsci-appspider-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/appspider-build-scanner-plugin/pull/26",
-    "description": "Hello jenkinsci-appspider-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello jenkinsci-appspider-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 16,
@@ -4367,7 +4685,8 @@
     "pluginName": "42crunch-security-audit",
     "labels": null,
     "url": "https://github.com/jenkinsci/42crunch-security-audit-plugin/pull/16",
-    "description": "Hello 42crunch-security-audit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello 42crunch-security-audit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 32,
@@ -4380,7 +4699,8 @@
     "pluginName": "blackduck-security-scan",
     "labels": null,
     "url": "https://github.com/jenkinsci/blackduck-security-scan-plugin/pull/32",
-    "description": "The goal of this PR is to update pom.xml to use https instead of http for repository URLs. The use of http is currently blocking me when attempting to update this plugin to use JDK 17, because of the following error:\n\nFound non-https repository URL in pom file preventing maven older than 3.8.1\nAlthough you are using a more recent version of Maven through mvnw, the tool I use (plugin-modernizer) relies on Maven directly.\n\nUpdates in pom.xml:\n\nChanged the repository URL with the id bds-artifactory to use an HTTPS URL ${repoReleaseArtifactoryUrl}.\nChanged the snapshot repository URL with the id bds-artifactory in the profile with the id snapshot-deployment to use an HTTPS URL ${snapshotArtifactoryUrl}.\nChanged the repository URL with the id bds-artifactory in the profile with the id deployment to use an HTTPS URL ${releaseArtifactoryUrl}.\nChanged the repository URL with the id bds-artifactory in the profile with the id qa-deployment to use an HTTPS URL ${qaArtifactoryUrl}.\nChanged the snapshot repository URL with the id bds-artifactory in the profile with the id qa-deployment to use an HTTPS URL ${snapshotArtifactoryUrl}.\n\nTesting done\nmvn clean verify\nSubmitter checklist\n\n Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!\n Ensure that the pull request title represents the desired changelog entry\n Please describe what you did\n Link to relevant issues in GitHub or Jira\n Link to relevant pull requests, esp. upstream and downstream changes\n Ensure you have provided tests - that demonstrates feature works or fixes the issue"
+    "description": "The goal of this PR is to update pom.xml to use https instead of http for repository URLs. The use of http is currently blocking me when attempting to update this plugin to use JDK 17, because of the following error:\n\nFound non-https repository URL in pom file preventing maven older than 3.8.1\nAlthough you are using a more recent version of Maven through mvnw, the tool I use (plugin-modernizer) relies on Maven directly.\n\nUpdates in pom.xml:\n\nChanged the repository URL with the id bds-artifactory to use an HTTPS URL ${repoReleaseArtifactoryUrl}.\nChanged the snapshot repository URL with the id bds-artifactory in the profile with the id snapshot-deployment to use an HTTPS URL ${snapshotArtifactoryUrl}.\nChanged the repository URL with the id bds-artifactory in the profile with the id deployment to use an HTTPS URL ${releaseArtifactoryUrl}.\nChanged the repository URL with the id bds-artifactory in the profile with the id qa-deployment to use an HTTPS URL ${qaArtifactoryUrl}.\nChanged the snapshot repository URL with the id bds-artifactory in the profile with the id qa-deployment to use an HTTPS URL ${snapshotArtifactoryUrl}.\n\nTesting done\nmvn clean verify\nSubmitter checklist\n\n Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!\n Ensure that the pull request title represents the desired changelog entry\n Please describe what you did\n Link to relevant issues in GitHub or Jira\n Link to relevant pull requests, esp. upstream and downstream changes\n Ensure you have provided tests - that demonstrates feature works or fixes the issue",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -4393,7 +4713,8 @@
     "pluginName": "embotics-vcommander",
     "labels": null,
     "url": "https://github.com/jenkinsci/snowsoftware-commander-plugin/pull/4",
-    "description": "Hello embotics-vcommander developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!\nSupersedes #3 ."
+    "description": "Hello embotics-vcommander developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!\nSupersedes #3 .",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 193,
@@ -4408,7 +4729,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/msbuild-plugin/pull/193",
-    "description": "Hello msbuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello msbuild developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 57,
@@ -4421,7 +4743,8 @@
     "pluginName": "dagshub-branch-source",
     "labels": null,
     "url": "https://github.com/jenkinsci/dagshub-branch-source-plugin/pull/57",
-    "description": "Hello dagshub-branch-source developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello dagshub-branch-source developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 67,
@@ -4434,7 +4757,8 @@
     "pluginName": "sectioned-view",
     "labels": null,
     "url": "https://github.com/jenkinsci/sectioned-view-plugin/pull/67",
-    "description": "Hello sectioned-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nThis could help #64 to pass checks, or even become redundant.\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello sectioned-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nThis could help #64 to pass checks, or even become redundant.\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 187,
@@ -4449,7 +4773,8 @@
       "enhancement"
     ],
     "url": "https://github.com/jenkinsci/job-restrictions-plugin/pull/187",
-    "description": "Hello job-restrictions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello job-restrictions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 83,
@@ -4465,7 +4790,8 @@
       "feature"
     ],
     "url": "https://github.com/jenkinsci/artifactdeployer-plugin/pull/83",
-    "description": "Hello artifactdeployer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello artifactdeployer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 18,
@@ -4478,7 +4804,8 @@
     "pluginName": "pipeline-global-lib-nexus",
     "labels": null,
     "url": "https://github.com/jenkinsci/pipeline-global-lib-nexus-plugin/pull/18",
-    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 17,
@@ -4491,7 +4818,8 @@
     "pluginName": "pipeline-global-lib-nexus",
     "labels": null,
     "url": "https://github.com/jenkinsci/pipeline-global-lib-nexus-plugin/pull/17",
-    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello pipeline-global-lib-nexus developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 43,
@@ -4507,7 +4835,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/database-sqlserver-plugin/pull/43",
-    "description": "Hello database-sqlserver developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello database-sqlserver developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 28,
@@ -4520,7 +4849,8 @@
     "pluginName": "ansible-tower",
     "labels": null,
     "url": "https://github.com/jenkinsci/ansible-tower-plugin/pull/28",
-    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 27,
@@ -4533,7 +4863,8 @@
     "pluginName": "ansible-tower",
     "labels": null,
     "url": "https://github.com/jenkinsci/ansible-tower-plugin/pull/27",
-    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 26,
@@ -4546,7 +4877,8 @@
     "pluginName": "ansible-tower",
     "labels": null,
     "url": "https://github.com/jenkinsci/ansible-tower-plugin/pull/26",
-    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello ansible-tower developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 31,
@@ -4559,7 +4891,8 @@
     "pluginName": "yet-another-build-visualizer",
     "labels": null,
     "url": "https://github.com/jenkinsci/yet-another-build-visualizer-plugin/pull/31",
-    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 30,
@@ -4572,7 +4905,8 @@
     "pluginName": "yet-another-build-visualizer",
     "labels": null,
     "url": "https://github.com/jenkinsci/yet-another-build-visualizer-plugin/pull/30",
-    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello yet-another-build-visualizer developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 52,
@@ -4588,7 +4922,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/sqlserver-api-plugin/pull/52",
-    "description": "Hello sqlserver-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello sqlserver-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 152,
@@ -4604,7 +4939,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/152",
-    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -4620,7 +4956,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/7",
-    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 121,
@@ -4635,7 +4972,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/pull/121",
-    "description": "Hello cloudbees-disk-usage-simple developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello cloudbees-disk-usage-simple developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 245,
@@ -4651,7 +4989,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/245",
-    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 361,
@@ -4667,7 +5006,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/361",
-    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 187,
@@ -4683,7 +5023,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/187",
-    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 119,
@@ -4699,7 +5040,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/119",
-    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 246,
@@ -4715,7 +5057,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/246",
-    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 143,
@@ -4731,7 +5074,8 @@
       "enhancement"
     ],
     "url": "https://github.com/jenkinsci/nunit-plugin/pull/143",
-    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 164,
@@ -4747,7 +5091,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/next-executions-plugin/pull/164",
-    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 137,
@@ -4763,7 +5108,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/login-theme-plugin/pull/137",
-    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 287,
@@ -4779,7 +5125,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/locale-plugin/pull/287",
-    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 399,
@@ -4795,7 +5142,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/399",
-    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 189,
@@ -4811,7 +5159,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/189",
-    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 220,
@@ -4827,7 +5176,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/220",
-    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 108,
@@ -4843,7 +5193,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/108",
-    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 155,
@@ -4859,7 +5210,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/file-operations-plugin/pull/155",
-    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 142,
@@ -4875,7 +5227,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/142",
-    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 121,
@@ -4891,7 +5244,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/121",
-    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 72,
@@ -4907,7 +5261,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/72",
-    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 87,
@@ -4923,7 +5278,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/87",
-    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 269,
@@ -4939,7 +5295,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/269",
-    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 100,
@@ -4955,7 +5312,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/100",
-    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 244,
@@ -4970,7 +5328,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/244",
-    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 186,
@@ -4985,7 +5344,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/186",
-    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 245,
@@ -5000,7 +5360,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/245",
-    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 163,
@@ -5015,7 +5376,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/next-executions-plugin/pull/163",
-    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 62,
@@ -5030,7 +5392,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/62",
-    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 108,
@@ -5045,7 +5408,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/108",
-    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 79,
@@ -5060,7 +5424,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/79",
-    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 69,
@@ -5075,7 +5440,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/json-api-plugin/pull/69",
-    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 63,
@@ -5090,7 +5456,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/63",
-    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 188,
@@ -5105,7 +5472,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/188",
-    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 66,
@@ -5120,7 +5488,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gson-api-plugin/pull/66",
-    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 219,
@@ -5135,7 +5504,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/219",
-    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 154,
@@ -5150,7 +5520,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/file-operations-plugin/pull/154",
-    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 141,
@@ -5165,7 +5536,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/141",
-    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 71,
@@ -5180,7 +5552,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/71",
-    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 22,
@@ -5195,7 +5568,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/22",
-    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 69,
@@ -5210,7 +5584,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/69",
-    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 70,
@@ -5225,7 +5600,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/asm-api-plugin/pull/70",
-    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 47,
@@ -5240,7 +5616,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/47",
-    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues."
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade BOM version\n    io.jenkins.tools.pluginmodernizer.UpgradeBomVersion\n    Upgrade the bom version to latest available for the current BOM.\n\nWhy is this important?\nBy using the latest version of the Jenkins BOM for the given baseline, you can ensure the plugin relies on the correct versions of Jenkins plugins and libraries. This can help prevent compatibility issues.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 10,
@@ -5253,7 +5630,8 @@
     "pluginName": "railflow-testrail",
     "labels": null,
     "url": "https://github.com/jenkinsci/railflow-testrail-plugin/pull/10",
-    "description": "Hello railflow-testrail developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello railflow-testrail developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 14,
@@ -5266,7 +5644,8 @@
     "pluginName": "deepcrawl-test",
     "labels": null,
     "url": "https://github.com/jenkinsci/deepcrawl-test-plugin/pull/14",
-    "description": "Hello deepcrawl-test developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello deepcrawl-test developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 13,
@@ -5279,7 +5658,8 @@
     "pluginName": "deepcrawl-test",
     "labels": null,
     "url": "https://github.com/jenkinsci/deepcrawl-test-plugin/pull/13",
-    "description": "Hello deepcrawl-test developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello deepcrawl-test developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 113,
@@ -5294,7 +5674,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/pipeline-cloudwatch-logs-plugin/pull/113",
-    "description": "Hello pipeline-cloudwatch-logs developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello pipeline-cloudwatch-logs developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 158,
@@ -5309,7 +5690,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/log-cli-plugin/pull/158",
-    "description": "Hello log-cli developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello log-cli developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 144,
@@ -5322,7 +5704,8 @@
     "pluginName": "groovy-events-listener-plugin",
     "labels": null,
     "url": "https://github.com/jenkinsci/groovy-events-listener-plugin/pull/144",
-    "description": "Hello groovy-events-listener-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello groovy-events-listener-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 4,
@@ -5335,7 +5718,8 @@
     "pluginName": "black-duck-sigma",
     "labels": null,
     "url": "https://github.com/jenkinsci/black-duck-sigma-plugin/pull/4",
-    "description": "Hello black-duck-sigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello black-duck-sigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 3,
@@ -5348,7 +5732,8 @@
     "pluginName": "black-duck-sigma",
     "labels": null,
     "url": "https://github.com/jenkinsci/black-duck-sigma-plugin/pull/3",
-    "description": "Hello black-duck-sigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello black-duck-sigma developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 268,
@@ -5363,7 +5748,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/268",
-    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 7,
@@ -5376,7 +5762,8 @@
     "pluginName": "appknox-scanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/appknox-scanner-plugin/pull/7",
-    "description": "Hello appknox-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello appknox-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nThe checks aren't checking, why is that?\nThe issue likely stems from your Jenkinsfile, which is still declaring Java 8 or 11.\nThe Jenkins infrastructure, in its wisdom, continues to use this, and does not allow the use of a Jenkinsfile supplied by a pull request.\nTo resolve this, a maintainer can replay the failed build by substituting the Jenkinsfile content with our proposed changes using the \"replay the build\" feature in Jenkins.\nPlease let us know if you need any assistance with this process.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 6,
@@ -5389,7 +5776,8 @@
     "pluginName": "appknox-scanner",
     "labels": null,
     "url": "https://github.com/jenkinsci/appknox-scanner-plugin/pull/6",
-    "description": "Hello appknox-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello appknox-scanner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 82,
@@ -5402,7 +5790,8 @@
     "pluginName": "github-pr-comment-build",
     "labels": null,
     "url": "https://github.com/jenkinsci/github-pr-comment-build-plugin/pull/82",
-    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 77,
@@ -5415,7 +5804,8 @@
     "pluginName": "github-pr-comment-build",
     "labels": null,
     "url": "https://github.com/jenkinsci/github-pr-comment-build-plugin/pull/77",
-    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 76,
@@ -5428,7 +5818,8 @@
     "pluginName": "github-pr-comment-build",
     "labels": null,
     "url": "https://github.com/jenkinsci/github-pr-comment-build-plugin/pull/76",
-    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello github-pr-comment-build developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 19,
@@ -5441,7 +5832,8 @@
     "pluginName": "xvnc",
     "labels": null,
     "url": "https://github.com/jenkinsci/xvnc-plugin/pull/19",
-    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 271,
@@ -5454,7 +5846,8 @@
     "pluginName": "jms-messaging",
     "labels": null,
     "url": "https://github.com/jenkinsci/jms-messaging-plugin/pull/271",
-    "description": "Hello jms-messaging developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello jms-messaging developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 18,
@@ -5467,7 +5860,8 @@
     "pluginName": "xvnc",
     "labels": null,
     "url": "https://github.com/jenkinsci/xvnc-plugin/pull/18",
-    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 397,
@@ -5480,7 +5874,8 @@
     "pluginName": "openstack-cloud",
     "labels": null,
     "url": "https://github.com/jenkinsci/openstack-cloud-plugin/pull/397",
-    "description": "Hello openstack-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello openstack-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 17,
@@ -5493,7 +5888,8 @@
     "pluginName": "xvnc",
     "labels": null,
     "url": "https://github.com/jenkinsci/xvnc-plugin/pull/17",
-    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 396,
@@ -5506,7 +5902,8 @@
     "pluginName": "openstack-cloud",
     "labels": null,
     "url": "https://github.com/jenkinsci/openstack-cloud-plugin/pull/396",
-    "description": "Hello openstack-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period."
+    "description": "Hello openstack-cloud developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 11\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion\n    Upgrade to latest LTS core version supporting Java 11.\n\nWhy is this important?\nTransitional Step to Java 17\nUpgrading to Jenkins LTS Core 2.462.3 is a critical step in our roadmap towards leveraging Java 17. This transition serves as an intermediary phase, ensuring that all systems are optimized for Java 11 before making the leap to Java 17.\nEnhancements and Security\nBy moving to this LTS version, we benefit from the latest performance and security improvements foundational to Java 11. Ensuring our dependencies are up-to-date and secure prepares the groundwork for a smoother transition to Java 17.\nLong-Term Support\nThe LTS version provides the necessary support and stability for Java 11, offering assurance during our gradual migration process. This allows us to take advantage of long-term updates and critical patches.\nEmbracing these incremental changes aligns our development environment with current standards and strategically positions us for future advancement. We appreciate your feedback and testing as we aim for a seamless adjustment period.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 16,
@@ -5519,7 +5916,8 @@
     "pluginName": "xvnc",
     "labels": null,
     "url": "https://github.com/jenkinsci/xvnc-plugin/pull/16",
-    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello xvnc developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "FAILURE"
   },
   {
     "number": 16,
@@ -5532,7 +5930,8 @@
     "pluginName": "permissive-script-security",
     "labels": null,
     "url": "https://github.com/jenkinsci/permissive-script-security-plugin/pull/16",
-    "description": "Hello permissive-script-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello permissive-script-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 15,
@@ -5545,7 +5944,8 @@
     "pluginName": "permissive-script-security",
     "labels": null,
     "url": "https://github.com/jenkinsci/permissive-script-security-plugin/pull/15",
-    "description": "Hello permissive-script-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed."
+    "description": "Hello permissive-script-security developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup dependabot\n    io.jenkins.tools.pluginmodernizer.SetupDependabot\n    Setup dependabot for the Jenkins plugin if it doesn't exist.\n\nWhy Automate with Dependabot?\nManaging dependencies can be a time-consuming and challenging task, especially when maintaining a Jenkins plugin.\nBy automating this process with Dependabot, you gain numerous advantages:\n\n\nKeep Pace with Innovation: Dependabot ensures\nyour plugin remains cutting-edge by promptly incorporating the latest features and enhancements from upstream libraries.\n\n\nStrengthen Security: Staying up-to-date with dependency updates is crucial for security.\nDependabot automatically flags and updates any vulnerable dependencies,\nhelping to protect your plugin from potential exploits.\n\n\nSave Time and Effort: Spend less time managing dependencies and more time innovating.\nDependabot automatically submits pull requests for new releases,\nallowing you to effortlessly review and integrate updates.\n\n\nEnhance Compatibility and Stability: Regular updates improve both performance and compatibility with other plugins and the Jenkins core,\nensuring a seamless experience for your users.\n\n\nImprove GitHub Integration: Dependabot streamlines and enhances the integration process with GitHub,\nmaking it easier to manage updates.\n\n\nEnhance the plugin health score: Regular updates contribute to a better health score by ensuring your plugin is reliable and up-to-date.\n\n\nFocus on What Matters: With Dependabot, you can concentrate on developing new features and fixing bugs, knowing that it handles dependency updates efficiently.\n\n\nSetting up Dependabot exemplifies a proactive approach to modern software maintenance, aligning your plugin with best practices in the industry. We invite you to test these updates and adopt a maintenance workflow that is both efficient and secure.\nYour insights and feedback are invaluable to us, and we are here to support you through this transition as needed.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 130,
@@ -5560,7 +5960,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/m2release-plugin/pull/130",
-    "description": "Hello m2release developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello m2release developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 171,
@@ -5576,7 +5977,8 @@
       "dependencies"
     ],
     "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/171",
-    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 128,
@@ -5592,7 +5994,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/pipeline-as-yaml-plugin/pull/128",
-    "description": "Hello pipeline-as-yaml developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello pipeline-as-yaml developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 270,
@@ -5605,7 +6008,8 @@
     "pluginName": "jms-messaging",
     "labels": null,
     "url": "https://github.com/jenkinsci/jms-messaging-plugin/pull/270",
-    "description": "Hello jms-messaging developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello jms-messaging developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "UNKNOWN"
   },
   {
     "number": 12,
@@ -5618,7 +6022,8 @@
     "pluginName": "favorite-view",
     "labels": null,
     "url": "https://github.com/jenkinsci/favorite-view-plugin/pull/12",
-    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request."
+    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "PENDING"
   },
   {
     "number": 10,
@@ -5631,7 +6036,8 @@
     "pluginName": "favorite-view",
     "labels": null,
     "url": "https://github.com/jenkinsci/favorite-view-plugin/pull/10",
-    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8."
+    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 9,
@@ -5644,7 +6050,8 @@
     "pluginName": "favorite-view",
     "labels": null,
     "url": "https://github.com/jenkinsci/favorite-view-plugin/pull/9",
-    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏"
+    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.462.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.462.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 8,
@@ -5659,7 +6066,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/favorite-view-plugin/pull/8",
-    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello favorite-view developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 13,
@@ -5672,7 +6080,8 @@
     "pluginName": "bitbucket-oauth",
     "labels": null,
     "url": "https://github.com/jenkinsci/bitbucket-oauth-plugin/pull/13",
-    "description": "Hello bitbucket-oauth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello bitbucket-oauth developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 1749,
@@ -5687,7 +6096,8 @@
       "chore"
     ],
     "url": "https://github.com/jenkinsci/gitlab-plugin/pull/1749",
-    "description": "Use Java 17 language features\nUse Java 17 pattern matching instanceof.  Makes the code easier to read by avoding the cast that often follows an instanceof.\nUse Java 17 string formatting.  Slight simplification of the code through OpenRewrite.\nUse Java 17 @serial annotation.  Annotation that may allow future checks for serialization.  No real benefit today as far as I can tell.\nSpecial thanks to OpenRewrite for https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17\nTesting done\nConfirmed that automated tests pass.\nSubmitter checklist\n\n Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!\n Ensure that the pull request title represents the desired changelog entry\n Please describe what you did\n Link to relevant issues in GitHub or Jira\n Link to relevant pull requests, esp. upstream and downstream changes\n Ensure you have provided tests - that demonstrates feature works or fixes the issue"
+    "description": "Use Java 17 language features\nUse Java 17 pattern matching instanceof.  Makes the code easier to read by avoding the cast that often follows an instanceof.\nUse Java 17 string formatting.  Slight simplification of the code through OpenRewrite.\nUse Java 17 @serial annotation.  Annotation that may allow future checks for serialization.  No real benefit today as far as I can tell.\nSpecial thanks to OpenRewrite for https://docs.openrewrite.org/recipes/java/migrate/upgradetojava17\nTesting done\nConfirmed that automated tests pass.\nSubmitter checklist\n\n Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!\n Ensure that the pull request title represents the desired changelog entry\n Please describe what you did\n Link to relevant issues in GitHub or Jira\n Link to relevant pull requests, esp. upstream and downstream changes\n Ensure you have provided tests - that demonstrates feature works or fixes the issue",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 32,
@@ -5703,7 +6113,8 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/mysql-api-plugin/pull/32",
-    "description": "Hello mysql-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello mysql-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   },
   {
     "number": 131,
@@ -5719,6 +6130,7 @@
       "developer"
     ],
     "url": "https://github.com/jenkinsci/database-mysql-plugin/pull/131",
-    "description": "Hello database-mysql developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!"
+    "description": "Hello database-mysql developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.479.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.479.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
   }
 ]


### PR DESCRIPTION
Fixes #27

Add the status of the PR checks to the result JSON files.

* Modify the GraphQL query in `jenkins-pr-collector.go` to include the status checks for each pull request.
* Add a new field `CheckStatus` to the `PullRequestData` struct in `jenkins-pr-collector.go` to store the status of the PR checks.
* Update the code that parses the GraphQL response to extract the status of the PR checks and store it in the new field in `PullRequestData`.
* Include the status of the PR checks in the generated report in `generate-report.sh`.
* Handle the status of the PR checks when uploading data to Google Sheets in `upload_to_sheets.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/alpha-omega-stats/pull/31?shareId=f59ce9df-312b-4d55-ad57-48a70b01e83b).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Pull requests now display commit status check information, offering users immediate insights into the health of recent commits.
	- Added a new field to show the state of status checks associated with commits in pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->