### PR TITLE
Streamline Maven build in test-jdk-25.sh; fix timeout log

### DIFF
--- a/data/monthly/filtered_prs_2025_07.json
+++ b/data/monthly/filtered_prs_2025_07.json
@@ -1,0 +1,880 @@
+[
+  {
+    "number": 194,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-31T13:34:57Z",
+    "updatedAt": "2025-07-31T13:34:58Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/reverse-proxy-auth-plugin",
+    "pluginName": "reverse-proxy-auth-plugin",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194",
+    "description": "Hello reverse-proxy-auth-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 3,
+    "title": "Require 2.346.3",
+    "state": "OPEN",
+    "createdAt": "2025-07-29T16:35:35Z",
+    "updatedAt": "2025-07-29T16:39:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/kryptowire-plugin",
+    "pluginName": "kryptowire",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/kryptowire-plugin/pull/3",
+    "description": "Hello kryptowire developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 472,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:31:19Z",
+    "updatedAt": "2025-07-29T18:09:09Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/472",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 470,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:07:52Z",
+    "updatedAt": "2025-07-31T06:05:25Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/470",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-28T18:02:23Z",
+    "updatedAt": "2025-07-28T18:04:03Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testfairy-plugin",
+    "pluginName": "TestFairy",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testfairy-plugin/pull/40",
+    "description": "Hello TestFairy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 282,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "CLOSED",
+    "createdAt": "2025-07-28T12:58:51Z",
+    "updatedAt": "2025-07-28T15:40:27Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/badge-plugin",
+    "pluginName": "badge",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/badge-plugin/pull/282",
+    "description": "Hello badge developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 271,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:11:18Z",
+    "updatedAt": "2025-07-27T11:23:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/271",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:09:13Z",
+    "updatedAt": "2025-07-27T11:23:52Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/30",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 377,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:06:41Z",
+    "updatedAt": "2025-07-27T11:13:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/377",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 16,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:04:40Z",
+    "updatedAt": "2025-07-27T11:12:11Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/16",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 12,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:02:45Z",
+    "updatedAt": "2025-07-27T11:11:32Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 215,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:00:48Z",
+    "updatedAt": "2025-07-27T11:08:27Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/215",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 52,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:59:00Z",
+    "updatedAt": "2025-07-27T11:08:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 131,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:57:10Z",
+    "updatedAt": "2025-07-27T11:08:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/131",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 278,
+    "title": "chore(pom): Use recommended core version 2.504.2",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:55:21Z",
+    "updatedAt": "2025-07-27T11:09:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/278",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.2, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.2 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 155,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:53:19Z",
+    "updatedAt": "2025-07-27T11:09:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/155",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 177,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:51:27Z",
+    "updatedAt": "2025-07-27T11:09:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/177",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 149,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:49:37Z",
+    "updatedAt": "2025-07-27T11:09:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/149",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 321,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:47:48Z",
+    "updatedAt": "2025-07-27T11:09:51Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/321",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:46:01Z",
+    "updatedAt": "2025-07-27T11:10:02Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/179",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:44:13Z",
+    "updatedAt": "2025-07-27T11:10:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 102,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:42:17Z",
+    "updatedAt": "2025-07-27T11:13:43Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/102",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 444,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:40:22Z",
+    "updatedAt": "2025-07-27T11:10:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/444",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 21,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:38:09Z",
+    "updatedAt": "2025-07-27T11:10:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/21",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 216,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:36:35Z",
+    "updatedAt": "2025-07-27T11:13:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/216",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 252,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:34:39Z",
+    "updatedAt": "2025-07-27T11:13:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/252",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 124,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:32:36Z",
+    "updatedAt": "2025-07-27T11:13:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/124",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 162,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:29:03Z",
+    "updatedAt": "2025-07-27T11:12:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/162",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 132,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:27:10Z",
+    "updatedAt": "2025-07-27T11:12:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/132",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:25:26Z",
+    "updatedAt": "2025-07-27T11:14:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/87",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 99,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:23:33Z",
+    "updatedAt": "2025-07-28T04:17:16Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/99",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 71,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:21:30Z",
+    "updatedAt": "2025-07-27T11:14:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/71",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 301,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:19:50Z",
+    "updatedAt": "2025-07-27T11:08:00Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 123,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:17:37Z",
+    "updatedAt": "2025-07-27T11:07:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/123",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 214,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:13:04Z",
+    "updatedAt": "2025-07-27T11:07:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 76,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:11:29Z",
+    "updatedAt": "2025-07-27T10:18:12Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/76",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:09:52Z",
+    "updatedAt": "2025-07-27T11:07:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 93,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:08:10Z",
+    "updatedAt": "2025-07-27T10:17:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/93",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 28,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:06:39Z",
+    "updatedAt": "2025-07-27T10:17:09Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/28",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:05:08Z",
+    "updatedAt": "2025-07-27T10:16:55Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/85",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 79,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:03:32Z",
+    "updatedAt": "2025-07-27T10:16:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/79",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:01:58Z",
+    "updatedAt": "2025-07-27T10:16:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/85",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 38,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:58:26Z",
+    "updatedAt": "2025-07-27T10:15:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/38",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 90,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:56:48Z",
+    "updatedAt": "2025-07-27T10:17:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:55:10Z",
+    "updatedAt": "2025-07-27T10:16:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/89",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 65,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:53:27Z",
+    "updatedAt": "2025-07-27T10:15:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/65",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:08:45Z",
+    "updatedAt": "2025-07-26T10:08:45Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/54",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 53,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:00:05Z",
+    "updatedAt": "2025-07-26T10:00:05Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 104,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T10:38:23Z",
+    "updatedAt": "2025-07-22T10:38:32Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/vectorcast-execution-plugin",
+    "pluginName": "vectorcast-execution",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/104",
+    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 30,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T07:40:48Z",
+    "updatedAt": "2025-07-22T09:27:49Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/zephyr-enterprise-test-management-plugin",
+    "pluginName": "zephyr-enterprise-test-management",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin/pull/30",
+    "description": "Hello zephyr-enterprise-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 88,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "CLOSED",
+    "createdAt": "2025-07-21T21:01:53Z",
+    "updatedAt": "2025-07-22T06:56:08Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/popper-api-plugin",
+    "pluginName": "popper-api",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/popper-api-plugin/pull/88",
+    "description": "Hello popper-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 8 and 11.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 6,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T17:34:11Z",
+    "updatedAt": "2025-07-21T17:34:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/humbug-plugin",
+    "pluginName": "humbug",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/humbug-plugin/pull/6",
+    "description": "Hello humbug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java .",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 110,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:53:12Z",
+    "updatedAt": "2025-07-21T17:15:06Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/110",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nThe Javadoc tool no longer supports the <tt> tag in HTML5 mode. I then replaced <tt> with <code> in the Javadoc comments.\nThat's why the master branch build fails. 🤷",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 109,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:25:03Z",
+    "updatedAt": "2025-07-21T16:46:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/109",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 15,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T13:26:59Z",
+    "updatedAt": "2025-07-21T13:30:59Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/requests-plugin",
+    "pluginName": "requests",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/requests-plugin/pull/15",
+    "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 8,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T11:45:22Z",
+    "updatedAt": "2025-07-23T09:04:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/blackduck-coverity-on-polaris-plugin",
+    "pluginName": "blackduck-coverity-on-polaris",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8",
+    "description": "Hello blackduck-coverity-on-polaris developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 25,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T10:08:35Z",
+    "updatedAt": "2025-07-21T10:12:29Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testcomplete-plugin",
+    "pluginName": "TestComplete",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testcomplete-plugin/pull/25",
+    "description": "Hello TestComplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  }
+]

--- a/data/monthly/filtered_prs_2025_08.json
+++ b/data/monthly/filtered_prs_2025_08.json
@@ -1,0 +1,688 @@
+[
+  {
+    "number": 275,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-15T11:29:57Z",
+    "updatedAt": "2025-08-15T19:40:55Z",
+    "user": "CodexRaunak",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/275",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 195,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T11:32:23Z",
+    "updatedAt": "2025-08-09T18:24:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-api-plugin",
+    "pluginName": "flyway-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/195",
+    "description": "Hello flyway-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 273,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:20:32Z",
+    "updatedAt": "2025-08-09T11:27:30Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/273",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 32,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:18:38Z",
+    "updatedAt": "2025-08-09T11:27:49Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 379,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:16:04Z",
+    "updatedAt": "2025-08-09T11:27:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/379",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 17,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:12:39Z",
+    "updatedAt": "2025-08-09T11:28:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/17",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 13,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:10:12Z",
+    "updatedAt": "2025-08-09T11:28:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/13",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:08:12Z",
+    "updatedAt": "2025-08-09T11:28:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/217",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:06:22Z",
+    "updatedAt": "2025-08-09T11:28:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:03:56Z",
+    "updatedAt": "2025-08-09T11:28:35Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/134",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 280,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:01:33Z",
+    "updatedAt": "2025-08-09T10:05:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 158,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:59:52Z",
+    "updatedAt": "2025-08-09T11:28:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/158",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:57:16Z",
+    "updatedAt": "2025-08-09T10:05:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/179",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 152,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:55:09Z",
+    "updatedAt": "2025-08-09T10:05:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/152",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 323,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:53:09Z",
+    "updatedAt": "2025-08-09T10:04:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/323",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 185,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:50:55Z",
+    "updatedAt": "2025-08-09T10:04:46Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/185",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 33,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:48:08Z",
+    "updatedAt": "2025-08-09T10:04:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/33",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 105,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:45:46Z",
+    "updatedAt": "2025-08-09T10:02:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/105",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 446,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:43:15Z",
+    "updatedAt": "2025-08-09T10:04:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/446",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 23,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:38:44Z",
+    "updatedAt": "2025-08-09T10:03:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/23",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 218,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:37:00Z",
+    "updatedAt": "2025-08-09T10:03:07Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/218",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 254,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:34:16Z",
+    "updatedAt": "2025-08-09T10:03:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/254",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:31:59Z",
+    "updatedAt": "2025-08-09T10:03:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/125",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 176,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:29:37Z",
+    "updatedAt": "2025-08-09T10:03:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/file-operations-plugin",
+    "pluginName": "file-operations",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/file-operations-plugin/pull/176",
+    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 164,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:26:32Z",
+    "updatedAt": "2025-08-09T09:36:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/164",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:24:32Z",
+    "updatedAt": "2025-08-09T09:36:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/134",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:22:36Z",
+    "updatedAt": "2025-08-09T09:36:08Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/89",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 101,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:20:52Z",
+    "updatedAt": "2025-08-09T09:36:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 73,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:18:45Z",
+    "updatedAt": "2025-08-09T09:35:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/73",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 303,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:16:22Z",
+    "updatedAt": "2025-08-09T09:35:45Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/303",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 128,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:13:53Z",
+    "updatedAt": "2025-08-09T09:35:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/128",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:03:15Z",
+    "updatedAt": "2025-08-09T09:15:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 78,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:01:19Z",
+    "updatedAt": "2025-08-09T09:15:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/78",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 126,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:59:29Z",
+    "updatedAt": "2025-08-09T09:09:37Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 94,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:57:36Z",
+    "updatedAt": "2025-08-09T09:04:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/94",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 29,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:55:42Z",
+    "updatedAt": "2025-08-09T09:08:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/29",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 86,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:53:53Z",
+    "updatedAt": "2025-08-09T09:07:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/86",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 80,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:51:52Z",
+    "updatedAt": "2025-08-09T08:59:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/80",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:49:58Z",
+    "updatedAt": "2025-08-09T09:08:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/87",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:44:24Z",
+    "updatedAt": "2025-08-09T08:54:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/40",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 92,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:42:39Z",
+    "updatedAt": "2025-08-09T08:54:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/92",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 91,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:40:57Z",
+    "updatedAt": "2025-08-09T08:54:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/91",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 68,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:39:14Z",
+    "updatedAt": "2025-08-09T08:49:58Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/68",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  }
+]

--- a/data/monthly/prs_2025_07.json
+++ b/data/monthly/prs_2025_07.json
@@ -1,0 +1,880 @@
+[
+  {
+    "number": 194,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-31T13:34:57Z",
+    "updatedAt": "2025-07-31T13:34:58Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/reverse-proxy-auth-plugin",
+    "pluginName": "reverse-proxy-auth-plugin",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194",
+    "description": "Hello reverse-proxy-auth-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 3,
+    "title": "Require 2.346.3",
+    "state": "OPEN",
+    "createdAt": "2025-07-29T16:35:35Z",
+    "updatedAt": "2025-07-29T16:39:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/kryptowire-plugin",
+    "pluginName": "kryptowire",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/kryptowire-plugin/pull/3",
+    "description": "Hello kryptowire developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 472,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:31:19Z",
+    "updatedAt": "2025-07-29T18:09:09Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/472",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 470,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:07:52Z",
+    "updatedAt": "2025-07-31T06:05:25Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/470",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-28T18:02:23Z",
+    "updatedAt": "2025-07-28T18:04:03Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testfairy-plugin",
+    "pluginName": "TestFairy",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testfairy-plugin/pull/40",
+    "description": "Hello TestFairy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 282,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "CLOSED",
+    "createdAt": "2025-07-28T12:58:51Z",
+    "updatedAt": "2025-07-28T15:40:27Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/badge-plugin",
+    "pluginName": "badge",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/badge-plugin/pull/282",
+    "description": "Hello badge developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 271,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:11:18Z",
+    "updatedAt": "2025-07-27T11:23:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/271",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:09:13Z",
+    "updatedAt": "2025-07-27T11:23:52Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/30",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 377,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:06:41Z",
+    "updatedAt": "2025-07-27T11:13:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/377",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 16,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:04:40Z",
+    "updatedAt": "2025-07-27T11:12:11Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/16",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 12,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:02:45Z",
+    "updatedAt": "2025-07-27T11:11:32Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 215,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:00:48Z",
+    "updatedAt": "2025-07-27T11:08:27Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/215",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 52,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:59:00Z",
+    "updatedAt": "2025-07-27T11:08:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 131,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:57:10Z",
+    "updatedAt": "2025-07-27T11:08:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/131",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 278,
+    "title": "chore(pom): Use recommended core version 2.504.2",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:55:21Z",
+    "updatedAt": "2025-07-27T11:09:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/278",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.2, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.2 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 155,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:53:19Z",
+    "updatedAt": "2025-07-27T11:09:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/155",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 177,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:51:27Z",
+    "updatedAt": "2025-07-27T11:09:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/177",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 149,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:49:37Z",
+    "updatedAt": "2025-07-27T11:09:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/149",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 321,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:47:48Z",
+    "updatedAt": "2025-07-27T11:09:51Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/321",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:46:01Z",
+    "updatedAt": "2025-07-27T11:10:02Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/179",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:44:13Z",
+    "updatedAt": "2025-07-27T11:10:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 102,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:42:17Z",
+    "updatedAt": "2025-07-27T11:13:43Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/102",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 444,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:40:22Z",
+    "updatedAt": "2025-07-27T11:10:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/444",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 21,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:38:09Z",
+    "updatedAt": "2025-07-27T11:10:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/21",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 216,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:36:35Z",
+    "updatedAt": "2025-07-27T11:13:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/216",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 252,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:34:39Z",
+    "updatedAt": "2025-07-27T11:13:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/252",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 124,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:32:36Z",
+    "updatedAt": "2025-07-27T11:13:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/124",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 162,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:29:03Z",
+    "updatedAt": "2025-07-27T11:12:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/162",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 132,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:27:10Z",
+    "updatedAt": "2025-07-27T11:12:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/132",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:25:26Z",
+    "updatedAt": "2025-07-27T11:14:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/87",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 99,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:23:33Z",
+    "updatedAt": "2025-07-28T04:17:16Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/99",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 71,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:21:30Z",
+    "updatedAt": "2025-07-27T11:14:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/71",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 301,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:19:50Z",
+    "updatedAt": "2025-07-27T11:08:00Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 123,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:17:37Z",
+    "updatedAt": "2025-07-27T11:07:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/123",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 214,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:13:04Z",
+    "updatedAt": "2025-07-27T11:07:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 76,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:11:29Z",
+    "updatedAt": "2025-07-27T10:18:12Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/76",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:09:52Z",
+    "updatedAt": "2025-07-27T11:07:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 93,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:08:10Z",
+    "updatedAt": "2025-07-27T10:17:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/93",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 28,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:06:39Z",
+    "updatedAt": "2025-07-27T10:17:09Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/28",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:05:08Z",
+    "updatedAt": "2025-07-27T10:16:55Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/85",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 79,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:03:32Z",
+    "updatedAt": "2025-07-27T10:16:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/79",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:01:58Z",
+    "updatedAt": "2025-07-27T10:16:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/85",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 38,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:58:26Z",
+    "updatedAt": "2025-07-27T10:15:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/38",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 90,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:56:48Z",
+    "updatedAt": "2025-07-27T10:17:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:55:10Z",
+    "updatedAt": "2025-07-27T10:16:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/89",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 65,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:53:27Z",
+    "updatedAt": "2025-07-27T10:15:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/65",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:08:45Z",
+    "updatedAt": "2025-07-26T10:08:45Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/54",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 53,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:00:05Z",
+    "updatedAt": "2025-07-26T10:00:05Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 104,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T10:38:23Z",
+    "updatedAt": "2025-07-22T10:38:32Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/vectorcast-execution-plugin",
+    "pluginName": "vectorcast-execution",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/104",
+    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 30,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T07:40:48Z",
+    "updatedAt": "2025-07-22T09:27:49Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/zephyr-enterprise-test-management-plugin",
+    "pluginName": "zephyr-enterprise-test-management",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin/pull/30",
+    "description": "Hello zephyr-enterprise-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 88,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "CLOSED",
+    "createdAt": "2025-07-21T21:01:53Z",
+    "updatedAt": "2025-07-22T06:56:08Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/popper-api-plugin",
+    "pluginName": "popper-api",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/popper-api-plugin/pull/88",
+    "description": "Hello popper-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 8 and 11.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 6,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T17:34:11Z",
+    "updatedAt": "2025-07-21T17:34:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/humbug-plugin",
+    "pluginName": "humbug",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/humbug-plugin/pull/6",
+    "description": "Hello humbug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java .",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 110,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:53:12Z",
+    "updatedAt": "2025-07-21T17:15:06Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/110",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nThe Javadoc tool no longer supports the \u003ctt\u003e tag in HTML5 mode. I then replaced \u003ctt\u003e with \u003ccode\u003e in the Javadoc comments.\nThat's why the master branch build fails. 🤷",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 109,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:25:03Z",
+    "updatedAt": "2025-07-21T16:46:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/109",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 15,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T13:26:59Z",
+    "updatedAt": "2025-07-21T13:30:59Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/requests-plugin",
+    "pluginName": "requests",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/requests-plugin/pull/15",
+    "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 8,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T11:45:22Z",
+    "updatedAt": "2025-07-23T09:04:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/blackduck-coverity-on-polaris-plugin",
+    "pluginName": "blackduck-coverity-on-polaris",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8",
+    "description": "Hello blackduck-coverity-on-polaris developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 25,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T10:08:35Z",
+    "updatedAt": "2025-07-21T10:12:29Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testcomplete-plugin",
+    "pluginName": "TestComplete",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testcomplete-plugin/pull/25",
+    "description": "Hello TestComplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  }
+]

--- a/data/monthly/prs_2025_08.json
+++ b/data/monthly/prs_2025_08.json
@@ -1,0 +1,688 @@
+[
+  {
+    "number": 275,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-15T11:29:57Z",
+    "updatedAt": "2025-08-15T19:40:55Z",
+    "user": "CodexRaunak",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/275",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 195,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T11:32:23Z",
+    "updatedAt": "2025-08-09T18:24:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-api-plugin",
+    "pluginName": "flyway-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/195",
+    "description": "Hello flyway-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 273,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:20:32Z",
+    "updatedAt": "2025-08-09T11:27:30Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/273",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 32,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:18:38Z",
+    "updatedAt": "2025-08-09T11:27:49Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 379,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:16:04Z",
+    "updatedAt": "2025-08-09T11:27:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/379",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 17,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:12:39Z",
+    "updatedAt": "2025-08-09T11:28:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/17",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 13,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:10:12Z",
+    "updatedAt": "2025-08-09T11:28:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/13",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:08:12Z",
+    "updatedAt": "2025-08-09T11:28:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/217",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:06:22Z",
+    "updatedAt": "2025-08-09T11:28:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:03:56Z",
+    "updatedAt": "2025-08-09T11:28:35Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/134",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 280,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:01:33Z",
+    "updatedAt": "2025-08-09T10:05:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 158,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:59:52Z",
+    "updatedAt": "2025-08-09T11:28:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/158",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:57:16Z",
+    "updatedAt": "2025-08-09T10:05:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/179",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 152,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:55:09Z",
+    "updatedAt": "2025-08-09T10:05:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/152",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 323,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:53:09Z",
+    "updatedAt": "2025-08-09T10:04:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/323",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 185,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:50:55Z",
+    "updatedAt": "2025-08-09T10:04:46Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/185",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 33,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:48:08Z",
+    "updatedAt": "2025-08-09T10:04:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/33",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 105,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:45:46Z",
+    "updatedAt": "2025-08-09T10:02:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/105",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 446,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:43:15Z",
+    "updatedAt": "2025-08-09T10:04:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/446",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 23,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:38:44Z",
+    "updatedAt": "2025-08-09T10:03:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/23",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 218,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:37:00Z",
+    "updatedAt": "2025-08-09T10:03:07Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/218",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 254,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:34:16Z",
+    "updatedAt": "2025-08-09T10:03:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/254",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:31:59Z",
+    "updatedAt": "2025-08-09T10:03:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/125",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 176,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:29:37Z",
+    "updatedAt": "2025-08-09T10:03:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/file-operations-plugin",
+    "pluginName": "file-operations",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/file-operations-plugin/pull/176",
+    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 164,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:26:32Z",
+    "updatedAt": "2025-08-09T09:36:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/164",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:24:32Z",
+    "updatedAt": "2025-08-09T09:36:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/134",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:22:36Z",
+    "updatedAt": "2025-08-09T09:36:08Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/89",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 101,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:20:52Z",
+    "updatedAt": "2025-08-09T09:36:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 73,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:18:45Z",
+    "updatedAt": "2025-08-09T09:35:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/73",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 303,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:16:22Z",
+    "updatedAt": "2025-08-09T09:35:45Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/303",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 128,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:13:53Z",
+    "updatedAt": "2025-08-09T09:35:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/128",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:03:15Z",
+    "updatedAt": "2025-08-09T09:15:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 78,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:01:19Z",
+    "updatedAt": "2025-08-09T09:15:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/78",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 126,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:59:29Z",
+    "updatedAt": "2025-08-09T09:09:37Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 94,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:57:36Z",
+    "updatedAt": "2025-08-09T09:04:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/94",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 29,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:55:42Z",
+    "updatedAt": "2025-08-09T09:08:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/29",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 86,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:53:53Z",
+    "updatedAt": "2025-08-09T09:07:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/86",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 80,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:51:52Z",
+    "updatedAt": "2025-08-09T08:59:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/80",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:49:58Z",
+    "updatedAt": "2025-08-09T09:08:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/87",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:44:24Z",
+    "updatedAt": "2025-08-09T08:54:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/40",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 92,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:42:39Z",
+    "updatedAt": "2025-08-09T08:54:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/92",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 91,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:40:57Z",
+    "updatedAt": "2025-08-09T08:54:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/91",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 68,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:39:14Z",
+    "updatedAt": "2025-08-09T08:49:58Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/68",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  }
+]

--- a/data/monthly/prs_2025_08.json.partial
+++ b/data/monthly/prs_2025_08.json.partial
@@ -1,0 +1,16 @@
+[
+  {
+    "number": 275,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-15T11:29:57Z",
+    "updatedAt": "2025-08-15T19:40:55Z",
+    "user": "CodexRaunak",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/275",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  }
+]

--- a/filtered_prs_filtered_prs_2025_07.json
+++ b/filtered_prs_filtered_prs_2025_07.json
@@ -1,0 +1,880 @@
+[
+  {
+    "number": 194,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-31T13:34:57Z",
+    "updatedAt": "2025-07-31T13:34:58Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/reverse-proxy-auth-plugin",
+    "pluginName": "reverse-proxy-auth-plugin",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194",
+    "description": "Hello reverse-proxy-auth-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 3,
+    "title": "Require 2.346.3",
+    "state": "OPEN",
+    "createdAt": "2025-07-29T16:35:35Z",
+    "updatedAt": "2025-07-29T16:39:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/kryptowire-plugin",
+    "pluginName": "kryptowire",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/kryptowire-plugin/pull/3",
+    "description": "Hello kryptowire developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 472,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:31:19Z",
+    "updatedAt": "2025-07-29T18:09:09Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/472",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 470,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-29T16:07:52Z",
+    "updatedAt": "2025-07-31T06:05:25Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/ec2-fleet-plugin",
+    "pluginName": "ec2-fleet",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/470",
+    "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-28T18:02:23Z",
+    "updatedAt": "2025-07-28T18:04:03Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testfairy-plugin",
+    "pluginName": "TestFairy",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testfairy-plugin/pull/40",
+    "description": "Hello TestFairy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 282,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "CLOSED",
+    "createdAt": "2025-07-28T12:58:51Z",
+    "updatedAt": "2025-07-28T15:40:27Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/badge-plugin",
+    "pluginName": "badge",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/badge-plugin/pull/282",
+    "description": "Hello badge developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 271,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:11:18Z",
+    "updatedAt": "2025-07-27T11:23:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/271",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:09:13Z",
+    "updatedAt": "2025-07-27T11:23:52Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/30",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 377,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:06:41Z",
+    "updatedAt": "2025-07-27T11:13:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/377",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 16,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:04:40Z",
+    "updatedAt": "2025-07-27T11:12:11Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/16",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 12,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:02:45Z",
+    "updatedAt": "2025-07-27T11:11:32Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 215,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T11:00:48Z",
+    "updatedAt": "2025-07-27T11:08:27Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/215",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 52,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:59:00Z",
+    "updatedAt": "2025-07-27T11:08:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 131,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:57:10Z",
+    "updatedAt": "2025-07-27T11:08:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/131",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 278,
+    "title": "chore(pom): Use recommended core version 2.504.2",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:55:21Z",
+    "updatedAt": "2025-07-27T11:09:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/278",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.2, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.2 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 155,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:53:19Z",
+    "updatedAt": "2025-07-27T11:09:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/155",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 177,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:51:27Z",
+    "updatedAt": "2025-07-27T11:09:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/177",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 149,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:49:37Z",
+    "updatedAt": "2025-07-27T11:09:38Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/149",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 321,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:47:48Z",
+    "updatedAt": "2025-07-27T11:09:51Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/321",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:46:01Z",
+    "updatedAt": "2025-07-27T11:10:02Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/179",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 30,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:44:13Z",
+    "updatedAt": "2025-07-27T11:10:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 102,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:42:17Z",
+    "updatedAt": "2025-07-27T11:13:43Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/102",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 444,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:40:22Z",
+    "updatedAt": "2025-07-27T11:10:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/444",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 21,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:38:09Z",
+    "updatedAt": "2025-07-27T11:10:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/21",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 216,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:36:35Z",
+    "updatedAt": "2025-07-27T11:13:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/216",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 252,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:34:39Z",
+    "updatedAt": "2025-07-27T11:13:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/252",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 124,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:32:36Z",
+    "updatedAt": "2025-07-27T11:13:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/124",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 162,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:29:03Z",
+    "updatedAt": "2025-07-27T11:12:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/162",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 132,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:27:10Z",
+    "updatedAt": "2025-07-27T11:12:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/132",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:25:26Z",
+    "updatedAt": "2025-07-27T11:14:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/87",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 99,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:23:33Z",
+    "updatedAt": "2025-07-28T04:17:16Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/99",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 71,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:21:30Z",
+    "updatedAt": "2025-07-27T11:14:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/71",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 301,
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:19:50Z",
+    "updatedAt": "2025-07-27T11:08:00Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 123,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:17:37Z",
+    "updatedAt": "2025-07-27T11:07:50Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/123",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 214,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:13:04Z",
+    "updatedAt": "2025-07-27T11:07:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 76,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:11:29Z",
+    "updatedAt": "2025-07-27T10:18:12Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/76",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:09:52Z",
+    "updatedAt": "2025-07-27T11:07:17Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 93,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:08:10Z",
+    "updatedAt": "2025-07-27T10:17:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/93",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 28,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:06:39Z",
+    "updatedAt": "2025-07-27T10:17:09Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/28",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:05:08Z",
+    "updatedAt": "2025-07-27T10:16:55Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/85",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 79,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:03:32Z",
+    "updatedAt": "2025-07-27T10:16:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/79",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 85,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T10:01:58Z",
+    "updatedAt": "2025-07-27T10:16:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/85",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 38,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:58:26Z",
+    "updatedAt": "2025-07-27T10:15:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/38",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 90,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:56:48Z",
+    "updatedAt": "2025-07-27T10:17:48Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:55:10Z",
+    "updatedAt": "2025-07-27T10:16:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/89",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 65,
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "state": "MERGED",
+    "createdAt": "2025-07-27T09:53:27Z",
+    "updatedAt": "2025-07-27T10:15:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "developer"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/65",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "chore(github): Add CODEOWNERS",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:08:45Z",
+    "updatedAt": "2025-07-26T10:08:45Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/54",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 53,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-26T10:00:05Z",
+    "updatedAt": "2025-07-26T10:00:05Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/cloudbees-enabler-plugin",
+    "pluginName": "cloudbees-enabler",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53",
+    "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 104,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T10:38:23Z",
+    "updatedAt": "2025-07-22T10:38:32Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/vectorcast-execution-plugin",
+    "pluginName": "vectorcast-execution",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/104",
+    "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 30,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-22T07:40:48Z",
+    "updatedAt": "2025-07-22T09:27:49Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/zephyr-enterprise-test-management-plugin",
+    "pluginName": "zephyr-enterprise-test-management",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin/pull/30",
+    "description": "Hello zephyr-enterprise-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 88,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "CLOSED",
+    "createdAt": "2025-07-21T21:01:53Z",
+    "updatedAt": "2025-07-22T06:56:08Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/popper-api-plugin",
+    "pluginName": "popper-api",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/popper-api-plugin/pull/88",
+    "description": "Hello popper-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 8 and 11.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 6,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T17:34:11Z",
+    "updatedAt": "2025-07-21T17:34:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/humbug-plugin",
+    "pluginName": "humbug",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/humbug-plugin/pull/6",
+    "description": "Hello humbug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java .",
+    "checkStatus": "UNKNOWN"
+  },
+  {
+    "number": 110,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:53:12Z",
+    "updatedAt": "2025-07-21T17:15:06Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/110",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nThe Javadoc tool no longer supports the <tt> tag in HTML5 mode. I then replaced <tt> with <code> in the Javadoc comments.\nThat's why the master branch build fails. 🤷",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 109,
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "state": "MERGED",
+    "createdAt": "2025-07-21T16:25:03Z",
+    "updatedAt": "2025-07-21T16:46:44Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/figlet-buildstep-plugin",
+    "pluginName": "figlet-buildstep",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/109",
+    "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 15,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T13:26:59Z",
+    "updatedAt": "2025-07-21T13:30:59Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/requests-plugin",
+    "pluginName": "requests",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/requests-plugin/pull/15",
+    "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 8,
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T11:45:22Z",
+    "updatedAt": "2025-07-23T09:04:11Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/blackduck-coverity-on-polaris-plugin",
+    "pluginName": "blackduck-coverity-on-polaris",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8",
+    "description": "Hello blackduck-coverity-on-polaris developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 25,
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "state": "OPEN",
+    "createdAt": "2025-07-21T10:08:35Z",
+    "updatedAt": "2025-07-21T10:12:29Z",
+    "user": "gounthar",
+    "repository": "jenkinsci/testcomplete-plugin",
+    "pluginName": "TestComplete",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/testcomplete-plugin/pull/25",
+    "description": "Hello TestComplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+    "checkStatus": "FAILURE"
+  }
+]

--- a/filtered_prs_filtered_prs_2025_08.json
+++ b/filtered_prs_filtered_prs_2025_08.json
@@ -1,0 +1,688 @@
+[
+  {
+    "number": 275,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-15T11:29:57Z",
+    "updatedAt": "2025-08-15T19:40:55Z",
+    "user": "CodexRaunak",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": null,
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/275",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 195,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T11:32:23Z",
+    "updatedAt": "2025-08-09T18:24:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-api-plugin",
+    "pluginName": "flyway-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/195",
+    "description": "Hello flyway-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "FAILURE"
+  },
+  {
+    "number": 273,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:20:32Z",
+    "updatedAt": "2025-08-09T11:27:30Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/skip-notifications-trait-plugin",
+    "pluginName": "skip-notifications-trait",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/273",
+    "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 32,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:18:38Z",
+    "updatedAt": "2025-08-09T11:27:49Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+    "pluginName": "s3-jobcacher-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32",
+    "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 379,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:16:04Z",
+    "updatedAt": "2025-08-09T11:27:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+    "pluginName": "postgresql-fingerprint-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/379",
+    "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 17,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:12:39Z",
+    "updatedAt": "2025-08-09T11:28:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-oras-plugin",
+    "pluginName": "pipeline-cps-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/17",
+    "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 13,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:10:12Z",
+    "updatedAt": "2025-08-09T11:28:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-lib-oras-plugin",
+    "pluginName": "pipeline-lib-oras",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/13",
+    "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:08:12Z",
+    "updatedAt": "2025-08-09T11:28:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-npm-plugin",
+    "pluginName": "pipeline-npm",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/217",
+    "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 54,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:06:22Z",
+    "updatedAt": "2025-08-09T11:28:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/pipeline-cps-http-plugin",
+    "pluginName": "pipeline-cps-http",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54",
+    "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:03:56Z",
+    "updatedAt": "2025-08-09T11:28:35Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/parameter-separator-plugin",
+    "pluginName": "parameter-separator",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/134",
+    "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 280,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T10:01:33Z",
+    "updatedAt": "2025-08-09T10:05:06Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+    "pluginName": "openshift-k8s-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280",
+    "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 158,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:59:52Z",
+    "updatedAt": "2025-08-09T11:28:44Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/nunit-plugin",
+    "pluginName": "nunit",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/nunit-plugin/pull/158",
+    "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 179,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:57:16Z",
+    "updatedAt": "2025-08-09T10:05:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/next-executions-plugin",
+    "pluginName": "next-executions",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/next-executions-plugin/pull/179",
+    "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 152,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:55:09Z",
+    "updatedAt": "2025-08-09T10:05:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/login-theme-plugin",
+    "pluginName": "login-theme",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/login-theme-plugin/pull/152",
+    "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 323,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:53:09Z",
+    "updatedAt": "2025-08-09T10:04:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/locale-plugin",
+    "pluginName": "locale",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/locale-plugin/pull/323",
+    "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 185,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:50:55Z",
+    "updatedAt": "2025-08-09T10:04:46Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/junit-attachments-plugin",
+    "pluginName": "junit-attachments",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/185",
+    "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 33,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:48:08Z",
+    "updatedAt": "2025-08-09T10:04:40Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+    "pluginName": "jobcacher-oras-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/33",
+    "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 105,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:45:46Z",
+    "updatedAt": "2025-08-09T10:02:56Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+    "pluginName": "jobcacher-artifactory-storage",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/105",
+    "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 446,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:43:15Z",
+    "updatedAt": "2025-08-09T10:04:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jobcacher-plugin",
+    "pluginName": "jobcacher",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/446",
+    "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 23,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:38:44Z",
+    "updatedAt": "2025-08-09T10:03:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jcaptcha-plugin",
+    "pluginName": "jcaptcha-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/23",
+    "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 218,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:37:00Z",
+    "updatedAt": "2025-08-09T10:03:07Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/hidden-parameter-plugin",
+    "pluginName": "hidden-parameter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/218",
+    "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 254,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:34:16Z",
+    "updatedAt": "2025-08-09T10:03:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+    "pluginName": "gitlab-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/254",
+    "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 125,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:31:59Z",
+    "updatedAt": "2025-08-09T10:03:20Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/flyway-runner-plugin",
+    "pluginName": "flyway-runner",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/125",
+    "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 176,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:29:37Z",
+    "updatedAt": "2025-08-09T10:03:28Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/file-operations-plugin",
+    "pluginName": "file-operations",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/file-operations-plugin/pull/176",
+    "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 164,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:26:32Z",
+    "updatedAt": "2025-08-09T09:36:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extra-tool-installers-plugin",
+    "pluginName": "extra-tool-installers",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/164",
+    "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 134,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:24:32Z",
+    "updatedAt": "2025-08-09T09:36:22Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/extension-filter-plugin",
+    "pluginName": "extension-filter",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/134",
+    "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 89,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:22:36Z",
+    "updatedAt": "2025-08-09T09:36:08Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/database-mariadb-plugin",
+    "pluginName": "database-mariadb",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/89",
+    "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 101,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:20:52Z",
+    "updatedAt": "2025-08-09T09:36:01Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/coverage-badges-extension-plugin",
+    "pluginName": "coverage-badges-extension",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101",
+    "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 73,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:18:45Z",
+    "updatedAt": "2025-08-09T09:35:54Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/build-history-metrics-plugin",
+    "pluginName": "build-history-metrics-plugin",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/73",
+    "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 303,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:16:22Z",
+    "updatedAt": "2025-08-09T09:35:45Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+    "pluginName": "bitbucket-kubernetes-credentials",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/303",
+    "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 128,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:13:53Z",
+    "updatedAt": "2025-08-09T09:35:29Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+    "pluginName": "artifactory-artifact-manager",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/128",
+    "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 217,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:03:15Z",
+    "updatedAt": "2025-08-09T09:15:41Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/oss-symbols-api-plugin",
+    "pluginName": "oss-symbols-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217",
+    "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 78,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T09:01:19Z",
+    "updatedAt": "2025-08-09T09:15:34Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/mariadb-api-plugin",
+    "pluginName": "mariadb-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/78",
+    "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 126,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:59:29Z",
+    "updatedAt": "2025-08-09T09:09:37Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jnr-posix-api-plugin",
+    "pluginName": "jnr-posix-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126",
+    "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 94,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:57:36Z",
+    "updatedAt": "2025-08-09T09:04:23Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-path-api-plugin",
+    "pluginName": "json-path-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/94",
+    "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 29,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:55:42Z",
+    "updatedAt": "2025-08-09T09:08:04Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/jsoup-plugin",
+    "pluginName": "jsoup",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/jsoup-plugin/pull/29",
+    "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 86,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:53:53Z",
+    "updatedAt": "2025-08-09T09:07:57Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/json-api-plugin",
+    "pluginName": "json-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/json-api-plugin/pull/86",
+    "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 80,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:51:52Z",
+    "updatedAt": "2025-08-09T08:59:36Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/joda-time-api-plugin",
+    "pluginName": "joda-time-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/80",
+    "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 87,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:49:58Z",
+    "updatedAt": "2025-08-09T09:08:18Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/gson-api-plugin",
+    "pluginName": "gson-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/gson-api-plugin/pull/87",
+    "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 40,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:44:24Z",
+    "updatedAt": "2025-08-09T08:54:53Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/commons-math3-api-plugin",
+    "pluginName": "commons-math3-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/40",
+    "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 92,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:42:39Z",
+    "updatedAt": "2025-08-09T08:54:25Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/byte-buddy-api-plugin",
+    "pluginName": "byte-buddy-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/92",
+    "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 91,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:40:57Z",
+    "updatedAt": "2025-08-09T08:54:14Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/asm-api-plugin",
+    "pluginName": "asm-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/asm-api-plugin/pull/91",
+    "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  },
+  {
+    "number": 68,
+    "title": "Migrate plugins to Java 25 LTS",
+    "state": "MERGED",
+    "createdAt": "2025-08-09T08:39:14Z",
+    "updatedAt": "2025-08-09T08:49:58Z",
+    "user": "jonesbusy",
+    "repository": "jenkinsci/artifactory-client-api-plugin",
+    "pluginName": "artifactory-client-api",
+    "labels": [
+      "dependencies"
+    ],
+    "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/68",
+    "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+    "checkStatus": "SUCCESS"
+  }
+]

--- a/grouped_prs_filtered_prs_2025_07.json
+++ b/grouped_prs_filtered_prs_2025_07.json
@@ -1,0 +1,952 @@
+[
+  {
+    "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+    "merged": 0,
+    "open": 3,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 104,
+        "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+        "state": "OPEN",
+        "createdAt": "2025-07-22T10:38:23Z",
+        "updatedAt": "2025-07-22T10:38:32Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/vectorcast-execution-plugin",
+        "pluginName": "vectorcast-execution",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/vectorcast-execution-plugin/pull/104",
+        "description": "Hello vectorcast-execution developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+        "checkStatus": "FAILURE"
+      },
+      {
+        "number": 30,
+        "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+        "state": "OPEN",
+        "createdAt": "2025-07-22T07:40:48Z",
+        "updatedAt": "2025-07-22T09:27:49Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/zephyr-enterprise-test-management-plugin",
+        "pluginName": "zephyr-enterprise-test-management",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin/pull/30",
+        "description": "Hello zephyr-enterprise-test-management developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+        "checkStatus": "UNKNOWN"
+      },
+      {
+        "number": 8,
+        "title": "Add Jenkinsfile to build plugin on the Jenkins Infrastructure",
+        "state": "OPEN",
+        "createdAt": "2025-07-21T11:45:22Z",
+        "updatedAt": "2025-07-23T09:04:11Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/blackduck-coverity-on-polaris-plugin",
+        "pluginName": "blackduck-coverity-on-polaris",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8",
+        "description": "Hello blackduck-coverity-on-polaris developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "Require 2.346.3",
+    "merged": 0,
+    "open": 1,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 3,
+        "title": "Require 2.346.3",
+        "state": "OPEN",
+        "createdAt": "2025-07-29T16:35:35Z",
+        "updatedAt": "2025-07-29T16:39:44Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/kryptowire-plugin",
+        "pluginName": "kryptowire",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/kryptowire-plugin/pull/3",
+        "description": "Hello kryptowire developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to latest LTS core version supporting Java 8\n    io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion\n    Upgrade to latest LTS core version supporting Java 8.",
+        "checkStatus": "UNKNOWN"
+      }
+    ]
+  },
+  {
+    "title": "chore(github): Add CODEOWNERS",
+    "merged": 1,
+    "open": 1,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 472,
+        "title": "chore(github): Add CODEOWNERS",
+        "state": "MERGED",
+        "createdAt": "2025-07-29T16:31:19Z",
+        "updatedAt": "2025-07-29T18:09:09Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/ec2-fleet-plugin",
+        "pluginName": "ec2-fleet",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/472",
+        "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 54,
+        "title": "chore(github): Add CODEOWNERS",
+        "state": "OPEN",
+        "createdAt": "2025-07-26T10:08:45Z",
+        "updatedAt": "2025-07-26T10:08:45Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/cloudbees-enabler-plugin",
+        "pluginName": "cloudbees-enabler",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/54",
+        "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Add CODEOWNERS file\n    io.jenkins.tools.pluginmodernizer.AddCodeOwner\n    Adds a CODEOWNERS file to a Jenkins plugin.\n\nWhy is this important?\nTo improve GitHub integration and enhance the plugin health score.\nTesting Done\nNone. We rely on GitHub checks of the pull request.",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "chore(pom): Use recommended core version 2.492.3",
+    "merged": 32,
+    "open": 0,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 271,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:11:18Z",
+        "updatedAt": "2025-07-27T11:23:41Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/skip-notifications-trait-plugin",
+        "pluginName": "skip-notifications-trait",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/271",
+        "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 16,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:04:40Z",
+        "updatedAt": "2025-07-27T11:12:11Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-cps-oras-plugin",
+        "pluginName": "pipeline-cps-oras",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/16",
+        "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 12,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:02:45Z",
+        "updatedAt": "2025-07-27T11:11:32Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-lib-oras-plugin",
+        "pluginName": "pipeline-lib-oras",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12",
+        "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 215,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:00:48Z",
+        "updatedAt": "2025-07-27T11:08:27Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-npm-plugin",
+        "pluginName": "pipeline-npm",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/215",
+        "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 52,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:59:00Z",
+        "updatedAt": "2025-07-27T11:08:38Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-cps-http-plugin",
+        "pluginName": "pipeline-cps-http",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52",
+        "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 131,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:57:10Z",
+        "updatedAt": "2025-07-27T11:08:53Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/parameter-separator-plugin",
+        "pluginName": "parameter-separator",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/131",
+        "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 155,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:53:19Z",
+        "updatedAt": "2025-07-27T11:09:17Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/nunit-plugin",
+        "pluginName": "nunit",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/nunit-plugin/pull/155",
+        "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 177,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:51:27Z",
+        "updatedAt": "2025-07-27T11:09:29Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/next-executions-plugin",
+        "pluginName": "next-executions",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/next-executions-plugin/pull/177",
+        "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 149,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:49:37Z",
+        "updatedAt": "2025-07-27T11:09:38Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/login-theme-plugin",
+        "pluginName": "login-theme",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/login-theme-plugin/pull/149",
+        "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 321,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:47:48Z",
+        "updatedAt": "2025-07-27T11:09:51Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/locale-plugin",
+        "pluginName": "locale",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/locale-plugin/pull/321",
+        "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 179,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:46:01Z",
+        "updatedAt": "2025-07-27T11:10:02Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/junit-attachments-plugin",
+        "pluginName": "junit-attachments",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/179",
+        "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 30,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:44:13Z",
+        "updatedAt": "2025-07-27T11:10:50Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+        "pluginName": "jobcacher-oras-storage",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30",
+        "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 444,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:40:22Z",
+        "updatedAt": "2025-07-27T11:10:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-plugin",
+        "pluginName": "jobcacher",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/444",
+        "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 21,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:38:09Z",
+        "updatedAt": "2025-07-27T11:10:23Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jcaptcha-plugin",
+        "pluginName": "jcaptcha-plugin",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/21",
+        "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 124,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:32:36Z",
+        "updatedAt": "2025-07-27T11:13:01Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/flyway-runner-plugin",
+        "pluginName": "flyway-runner",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/124",
+        "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 162,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:29:03Z",
+        "updatedAt": "2025-07-27T11:12:48Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/extra-tool-installers-plugin",
+        "pluginName": "extra-tool-installers",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/162",
+        "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 132,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:27:10Z",
+        "updatedAt": "2025-07-27T11:12:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/extension-filter-plugin",
+        "pluginName": "extension-filter",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/132",
+        "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 99,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:23:33Z",
+        "updatedAt": "2025-07-28T04:17:16Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/coverage-badges-extension-plugin",
+        "pluginName": "coverage-badges-extension",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/99",
+        "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 71,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:21:30Z",
+        "updatedAt": "2025-07-27T11:14:20Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/build-history-metrics-plugin",
+        "pluginName": "build-history-metrics-plugin",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/71",
+        "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 123,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:17:37Z",
+        "updatedAt": "2025-07-27T11:07:50Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+        "pluginName": "artifactory-artifact-manager",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/123",
+        "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 214,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:13:04Z",
+        "updatedAt": "2025-07-27T11:07:40Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/oss-symbols-api-plugin",
+        "pluginName": "oss-symbols-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214",
+        "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 76,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:11:29Z",
+        "updatedAt": "2025-07-27T10:18:12Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/mariadb-api-plugin",
+        "pluginName": "mariadb-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/76",
+        "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 125,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:09:52Z",
+        "updatedAt": "2025-07-27T11:07:17Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jnr-posix-api-plugin",
+        "pluginName": "jnr-posix-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125",
+        "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 93,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:08:10Z",
+        "updatedAt": "2025-07-27T10:17:20Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/json-path-api-plugin",
+        "pluginName": "json-path-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/93",
+        "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 28,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:06:39Z",
+        "updatedAt": "2025-07-27T10:17:09Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jsoup-plugin",
+        "pluginName": "jsoup",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jsoup-plugin/pull/28",
+        "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 85,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:05:08Z",
+        "updatedAt": "2025-07-27T10:16:55Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/json-api-plugin",
+        "pluginName": "json-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/json-api-plugin/pull/85",
+        "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 79,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:03:32Z",
+        "updatedAt": "2025-07-27T10:16:44Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/joda-time-api-plugin",
+        "pluginName": "joda-time-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/79",
+        "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 85,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:01:58Z",
+        "updatedAt": "2025-07-27T10:16:22Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/gson-api-plugin",
+        "pluginName": "gson-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/gson-api-plugin/pull/85",
+        "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 38,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T09:58:26Z",
+        "updatedAt": "2025-07-27T10:15:36Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/commons-math3-api-plugin",
+        "pluginName": "commons-math3-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/38",
+        "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 90,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T09:56:48Z",
+        "updatedAt": "2025-07-27T10:17:48Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/byte-buddy-api-plugin",
+        "pluginName": "byte-buddy-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90",
+        "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 89,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T09:55:10Z",
+        "updatedAt": "2025-07-27T10:16:04Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/asm-api-plugin",
+        "pluginName": "asm-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/asm-api-plugin/pull/89",
+        "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 65,
+        "title": "chore(pom): Use recommended core version 2.492.3",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T09:53:27Z",
+        "updatedAt": "2025-07-27T10:15:57Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/artifactory-client-api-plugin",
+        "pluginName": "artifactory-client-api",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/65",
+        "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+    "merged": 5,
+    "open": 0,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 30,
+        "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:09:13Z",
+        "updatedAt": "2025-07-27T11:23:52Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+        "pluginName": "s3-jobcacher-storage",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/30",
+        "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 377,
+        "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T11:06:41Z",
+        "updatedAt": "2025-07-27T11:13:53Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+        "pluginName": "postgresql-fingerprint-storage",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/377",
+        "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 102,
+        "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:42:17Z",
+        "updatedAt": "2025-07-27T11:13:43Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+        "pluginName": "jobcacher-artifactory-storage",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/102",
+        "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 216,
+        "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:36:35Z",
+        "updatedAt": "2025-07-27T11:13:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/hidden-parameter-plugin",
+        "pluginName": "hidden-parameter",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/216",
+        "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 87,
+        "title": "chore(pom): Use recommended core version 2.492.3, and Java 11",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:25:26Z",
+        "updatedAt": "2025-07-27T11:14:48Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/database-mariadb-plugin",
+        "pluginName": "database-mariadb",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/87",
+        "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.492.3, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.492.3 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "chore(pom): Use recommended core version 2.504.1",
+    "merged": 2,
+    "open": 0,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 252,
+        "title": "chore(pom): Use recommended core version 2.504.1",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:34:39Z",
+        "updatedAt": "2025-07-27T11:13:25Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+        "pluginName": "gitlab-kubernetes-credentials",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/252",
+        "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 301,
+        "title": "chore(pom): Use recommended core version 2.504.1",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:19:50Z",
+        "updatedAt": "2025-07-27T11:08:00Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+        "pluginName": "bitbucket-kubernetes-credentials",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301",
+        "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.1, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.1 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "chore(pom): Use recommended core version 2.504.2",
+    "merged": 1,
+    "open": 0,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 278,
+        "title": "chore(pom): Use recommended core version 2.504.2",
+        "state": "MERGED",
+        "createdAt": "2025-07-27T10:55:21Z",
+        "updatedAt": "2025-07-27T11:09:06Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+        "pluginName": "openshift-k8s-credentials",
+        "labels": [
+          "developer"
+        ],
+        "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/278",
+        "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version\n    io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion\n    Upgrade to the latest recommended core version and ensure the BOM matches the core version.\n\nWhy is this important?\nJenkins plugins declare a minimum supported Jenkins version.\nThe minimum Jenkins version is a useful way for plugin developers to indicate the range of Jenkins versions they are willing to support and test.\nSee the developer documentation to learn more about the recommended minimum Jenkins version.\nThe current minimum required Jenkins version is 2.504.2, which is why this pull request has been made.\nIf the plugin is already using the plugin bill of materials, then the bill of materials also needs to be updated with the matching artifactId for the minimum required Jenkins version.\nI can't see any change to the Jenkins version, how come?\nThis means your plugin POM was already using the 2.504.2 version but still required a few adjustments.\nThe checks fail, why?\nFor security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.\nInstead, it builds the code using the Jenkinsfile from the default branch.\nIn this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.\nTo resolve this,\na maintainer can replay the failed build\nby substituting the current Jenkinsfile content with our proposed changes using the \"replay the build\"\nfeature in Jenkins.\nPlease let us know if you need any assistance with this process.\nThanks for taking the time to review this PR.\n🙏",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "feat(ci): Builds on the Jenkins Infrastructure",
+    "merged": 1,
+    "open": 1,
+    "closed": 1,
+    "prs": [
+      {
+        "number": 88,
+        "title": "feat(ci): Builds on the Jenkins Infrastructure",
+        "state": "CLOSED",
+        "createdAt": "2025-07-21T21:01:53Z",
+        "updatedAt": "2025-07-22T06:56:08Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/popper-api-plugin",
+        "pluginName": "popper-api",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/popper-api-plugin/pull/88",
+        "description": "Hello popper-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 8 and 11.\nThere will come a time when we no longer support plugins built with JDK 8 or 11.\nAfter this PR is merged, we will submit additional automated PRs to enable your plugin to build with Java 17 and 21.",
+        "checkStatus": "UNKNOWN"
+      },
+      {
+        "number": 6,
+        "title": "feat(ci): Builds on the Jenkins Infrastructure",
+        "state": "OPEN",
+        "createdAt": "2025-07-21T17:34:11Z",
+        "updatedAt": "2025-07-21T17:34:11Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/humbug-plugin",
+        "pluginName": "humbug",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/humbug-plugin/pull/6",
+        "description": "Hello humbug developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java .",
+        "checkStatus": "UNKNOWN"
+      },
+      {
+        "number": 109,
+        "title": "feat(ci): Builds on the Jenkins Infrastructure",
+        "state": "MERGED",
+        "createdAt": "2025-07-21T16:25:03Z",
+        "updatedAt": "2025-07-21T16:46:44Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/figlet-buildstep-plugin",
+        "pluginName": "figlet-buildstep",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/109",
+        "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Setup the Jenkinsfile\n    io.jenkins.tools.pluginmodernizer.SetupJenkinsfile\n    Add a missing Jenkinsfile to the Jenkins plugin.\n\nWhy is this important?\nThis pull request ensure your plugin is build on the Jenkins infrastructure.\nBased on your plugin requirements, the Jenkins infrastructure will build your plugin using Java 17 and 21.\nYour plugin is already building with Java 17 and 21. We will continue to support these versions.",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+    "merged": 2,
+    "open": 5,
+    "closed": 1,
+    "prs": [
+      {
+        "number": 194,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "OPEN",
+        "createdAt": "2025-07-31T13:34:57Z",
+        "updatedAt": "2025-07-31T13:34:58Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/reverse-proxy-auth-plugin",
+        "pluginName": "reverse-proxy-auth-plugin",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194",
+        "description": "Hello reverse-proxy-auth-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 470,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "MERGED",
+        "createdAt": "2025-07-29T16:07:52Z",
+        "updatedAt": "2025-07-31T06:05:25Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/ec2-fleet-plugin",
+        "pluginName": "ec2-fleet",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/ec2-fleet-plugin/pull/470",
+        "description": "Hello ec2-fleet developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 40,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "OPEN",
+        "createdAt": "2025-07-28T18:02:23Z",
+        "updatedAt": "2025-07-28T18:04:03Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/testfairy-plugin",
+        "pluginName": "TestFairy",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/testfairy-plugin/pull/40",
+        "description": "Hello TestFairy developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "UNKNOWN"
+      },
+      {
+        "number": 282,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "CLOSED",
+        "createdAt": "2025-07-28T12:58:51Z",
+        "updatedAt": "2025-07-28T15:40:27Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/badge-plugin",
+        "pluginName": "badge",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/badge-plugin/pull/282",
+        "description": "Hello badge developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "FAILURE"
+      },
+      {
+        "number": 53,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "OPEN",
+        "createdAt": "2025-07-26T10:00:05Z",
+        "updatedAt": "2025-07-26T10:00:05Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/cloudbees-enabler-plugin",
+        "pluginName": "cloudbees-enabler",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53",
+        "description": "Hello cloudbees-enabler developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.504.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.504.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 110,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "MERGED",
+        "createdAt": "2025-07-21T16:53:12Z",
+        "updatedAt": "2025-07-21T17:15:06Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/figlet-buildstep-plugin",
+        "pluginName": "figlet-buildstep",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/figlet-buildstep-plugin/pull/110",
+        "description": "Hello figlet-buildstep developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nThe Javadoc tool no longer supports the <tt> tag in HTML5 mode. I then replaced <tt> with <code> in the Javadoc comments.\nThat's why the master branch build fails. 🤷",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 15,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "OPEN",
+        "createdAt": "2025-07-21T13:26:59Z",
+        "updatedAt": "2025-07-21T13:30:59Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/requests-plugin",
+        "pluginName": "requests",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/requests-plugin/pull/15",
+        "description": "Hello requests developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "FAILURE"
+      },
+      {
+        "number": 25,
+        "title": "feat(java): Require Jenkins core 2.492.3 and Java 17",
+        "state": "OPEN",
+        "createdAt": "2025-07-21T10:08:35Z",
+        "updatedAt": "2025-07-21T10:12:29Z",
+        "user": "gounthar",
+        "repository": "jenkinsci/testcomplete-plugin",
+        "pluginName": "TestComplete",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/testcomplete-plugin/pull/25",
+        "description": "Hello TestComplete developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17\n    io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion\n    Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.\n\nWhy Upgrade to Java 17 and Jenkins 2.492.x?\n\n\nEmbrace Java 17 LTS Stability: Benefit from long-term support with modern language features that improve development practice and plugin performance.\n\n\nHarness Jenkins 2.492.x Innovations: Stay aligned with the latest features and stability improvements, ensuring smooth integration and future-proofing.\n\n\nEnhance Security: Protect your plugin with up-to-date security fixes from both Java 17 and Jenkins core improvements.\n\n\nAlign with the Community: Keep pace with ecosystem shifts towards Java 17, ensuring compatibility and expanding your plugin's user base.\n\n\nEnjoy a Better Developer Experience: Make the most of advanced tooling support and simplified dependency management with Java 17's enhancements.\n\n\nRemoving developers Tag from pom.xml\nJenkins no longer requires the developers tag in pom.xml, as the developers section was traditionally used to list individuals responsible for the plugin.\nInstead, Jenkins now uses the Repository Permission Updater (RPU) to manage permissions and developer information.\nBenefits of Removing developers Tag:\n\nSimplification: Removes unnecessary metadata from the pom.xml, resulting in a cleaner and more maintainable file.\nConsistency: Centralizes developer information management through the RPU, minimizing discrepancies.\nSecurity: Utilizes the RPU's controlled permission management, enhancing the security of artifact deployments.\n\nRemoving the developers tag aligns with modern Jenkins infrastructure standards and prevents outdated or redundant developer information from being included in plugin metadata.\nJEP-227: Replace Acegi Security with Spring Security\nMigrating Jenkins plugin code from Acegi Security to Spring Security is important for several reasons:\n\nSecurity updates: Spring Security is the modern, actively maintained successor to Acegi Security, providing up-to-date security features and patches.\nCompatibility: Jenkins core version 2.266 and later have replaced Acegi Security with Spring Security, so plugins need to be updated to remain compatible with newer Jenkins versions.\nEliminating false positives: Security scanners often flag the outdated Acegi Security library as vulnerable, causing unnecessary concerns and exemption requests in security-conscious organizations.\nReducing technical debt: The Acegi Security code in Jenkins was written over 13 years ago and has barely been touched since, making it difficult to maintain and understand.\nAccess to modern features: Spring Security offers more current security implementations and features that weren't available in Acegi Security.\nCommunity support: With the Jenkins ecosystem moving to Spring Security, plugins using the newer library will benefit from better community support and compatibility with other plugins.\nSimplified API: The migration offers an opportunity to introduce a new simplified security API in Jenkins, potentially making it easier for plugin developers to work with security-related functions.\n\nBy migrating to Spring Security, plugin developers ensure their code remains compatible with current Jenkins versions, benefit from modern security features, and contribute to a more secure and maintainable Jenkins ecosystem.\nSummary\nBy upgrading, you'll be positioning your plugin at the forefront of performance, security, and user satisfaction. We encourage you to explore these updates and provide feedback. Let's continue to build a robust Jenkins ecosystem together!",
+        "checkStatus": "FAILURE"
+      }
+    ]
+  }
+]

--- a/grouped_prs_filtered_prs_2025_08.json
+++ b/grouped_prs_filtered_prs_2025_08.json
@@ -1,0 +1,696 @@
+[
+  {
+    "title": "Migrate plugins to Java 25 LTS",
+    "merged": 43,
+    "open": 0,
+    "closed": 0,
+    "prs": [
+      {
+        "number": 275,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-15T11:29:57Z",
+        "updatedAt": "2025-08-15T19:40:55Z",
+        "user": "CodexRaunak",
+        "repository": "jenkinsci/skip-notifications-trait-plugin",
+        "pluginName": "skip-notifications-trait",
+        "labels": null,
+        "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/275",
+        "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 195,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T11:32:23Z",
+        "updatedAt": "2025-08-09T18:24:40Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/flyway-api-plugin",
+        "pluginName": "flyway-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/flyway-api-plugin/pull/195",
+        "description": "Hello flyway-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "FAILURE"
+      },
+      {
+        "number": 273,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:20:32Z",
+        "updatedAt": "2025-08-09T11:27:30Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/skip-notifications-trait-plugin",
+        "pluginName": "skip-notifications-trait",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/skip-notifications-trait-plugin/pull/273",
+        "description": "Hello skip-notifications-trait developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 32,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:18:38Z",
+        "updatedAt": "2025-08-09T11:27:49Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/s3-jobcacher-storage-plugin",
+        "pluginName": "s3-jobcacher-storage",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32",
+        "description": "Hello s3-jobcacher-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 379,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:16:04Z",
+        "updatedAt": "2025-08-09T11:27:56Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/postgresql-fingerprint-storage-plugin",
+        "pluginName": "postgresql-fingerprint-storage",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/pull/379",
+        "description": "Hello postgresql-fingerprint-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 17,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:12:39Z",
+        "updatedAt": "2025-08-09T11:28:04Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-cps-oras-plugin",
+        "pluginName": "pipeline-cps-oras",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-cps-oras-plugin/pull/17",
+        "description": "Hello pipeline-cps-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 13,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:10:12Z",
+        "updatedAt": "2025-08-09T11:28:14Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-lib-oras-plugin",
+        "pluginName": "pipeline-lib-oras",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/13",
+        "description": "Hello pipeline-lib-oras developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 217,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:08:12Z",
+        "updatedAt": "2025-08-09T11:28:20Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-npm-plugin",
+        "pluginName": "pipeline-npm",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-npm-plugin/pull/217",
+        "description": "Hello pipeline-npm developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 54,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:06:22Z",
+        "updatedAt": "2025-08-09T11:28:28Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/pipeline-cps-http-plugin",
+        "pluginName": "pipeline-cps-http",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54",
+        "description": "Hello pipeline-cps-http developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 134,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:03:56Z",
+        "updatedAt": "2025-08-09T11:28:35Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/parameter-separator-plugin",
+        "pluginName": "parameter-separator",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/parameter-separator-plugin/pull/134",
+        "description": "Hello parameter-separator developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 280,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T10:01:33Z",
+        "updatedAt": "2025-08-09T10:05:06Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/openshift-k8s-credentials-plugin",
+        "pluginName": "openshift-k8s-credentials",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280",
+        "description": "Hello openshift-k8s-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 158,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:59:52Z",
+        "updatedAt": "2025-08-09T11:28:44Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/nunit-plugin",
+        "pluginName": "nunit",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/nunit-plugin/pull/158",
+        "description": "Hello nunit developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 179,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:57:16Z",
+        "updatedAt": "2025-08-09T10:05:18Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/next-executions-plugin",
+        "pluginName": "next-executions",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/next-executions-plugin/pull/179",
+        "description": "Hello next-executions developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 152,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:55:09Z",
+        "updatedAt": "2025-08-09T10:05:01Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/login-theme-plugin",
+        "pluginName": "login-theme",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/login-theme-plugin/pull/152",
+        "description": "Hello login-theme developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 323,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:53:09Z",
+        "updatedAt": "2025-08-09T10:04:54Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/locale-plugin",
+        "pluginName": "locale",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/locale-plugin/pull/323",
+        "description": "Hello locale developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 185,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:50:55Z",
+        "updatedAt": "2025-08-09T10:04:46Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/junit-attachments-plugin",
+        "pluginName": "junit-attachments",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/junit-attachments-plugin/pull/185",
+        "description": "Hello junit-attachments developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 33,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:48:08Z",
+        "updatedAt": "2025-08-09T10:04:40Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-oras-storage-plugin",
+        "pluginName": "jobcacher-oras-storage",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/33",
+        "description": "Hello jobcacher-oras-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 105,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:45:46Z",
+        "updatedAt": "2025-08-09T10:02:56Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-artifactory-storage-plugin",
+        "pluginName": "jobcacher-artifactory-storage",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-artifactory-storage-plugin/pull/105",
+        "description": "Hello jobcacher-artifactory-storage developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 446,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:43:15Z",
+        "updatedAt": "2025-08-09T10:04:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jobcacher-plugin",
+        "pluginName": "jobcacher",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jobcacher-plugin/pull/446",
+        "description": "Hello jobcacher developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 23,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:38:44Z",
+        "updatedAt": "2025-08-09T10:03:01Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jcaptcha-plugin",
+        "pluginName": "jcaptcha-plugin",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jcaptcha-plugin/pull/23",
+        "description": "Hello jcaptcha-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 218,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:37:00Z",
+        "updatedAt": "2025-08-09T10:03:07Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/hidden-parameter-plugin",
+        "pluginName": "hidden-parameter",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/hidden-parameter-plugin/pull/218",
+        "description": "Hello hidden-parameter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 254,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:34:16Z",
+        "updatedAt": "2025-08-09T10:03:14Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/gitlab-kubernetes-credentials-plugin",
+        "pluginName": "gitlab-kubernetes-credentials",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/gitlab-kubernetes-credentials-plugin/pull/254",
+        "description": "Hello gitlab-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 125,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:31:59Z",
+        "updatedAt": "2025-08-09T10:03:20Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/flyway-runner-plugin",
+        "pluginName": "flyway-runner",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/flyway-runner-plugin/pull/125",
+        "description": "Hello flyway-runner developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 176,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:29:37Z",
+        "updatedAt": "2025-08-09T10:03:28Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/file-operations-plugin",
+        "pluginName": "file-operations",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/file-operations-plugin/pull/176",
+        "description": "Hello file-operations developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 164,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:26:32Z",
+        "updatedAt": "2025-08-09T09:36:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/extra-tool-installers-plugin",
+        "pluginName": "extra-tool-installers",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/extra-tool-installers-plugin/pull/164",
+        "description": "Hello extra-tool-installers developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 134,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:24:32Z",
+        "updatedAt": "2025-08-09T09:36:22Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/extension-filter-plugin",
+        "pluginName": "extension-filter",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/extension-filter-plugin/pull/134",
+        "description": "Hello extension-filter developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 89,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:22:36Z",
+        "updatedAt": "2025-08-09T09:36:08Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/database-mariadb-plugin",
+        "pluginName": "database-mariadb",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/database-mariadb-plugin/pull/89",
+        "description": "Hello database-mariadb developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 101,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:20:52Z",
+        "updatedAt": "2025-08-09T09:36:01Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/coverage-badges-extension-plugin",
+        "pluginName": "coverage-badges-extension",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101",
+        "description": "Hello coverage-badges-extension developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 73,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:18:45Z",
+        "updatedAt": "2025-08-09T09:35:54Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/build-history-metrics-plugin",
+        "pluginName": "build-history-metrics-plugin",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/73",
+        "description": "Hello build-history-metrics-plugin developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 303,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:16:22Z",
+        "updatedAt": "2025-08-09T09:35:45Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/bitbucket-kubernetes-credentials-plugin",
+        "pluginName": "bitbucket-kubernetes-credentials",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/303",
+        "description": "Hello bitbucket-kubernetes-credentials developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 128,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:13:53Z",
+        "updatedAt": "2025-08-09T09:35:29Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/artifactory-artifact-manager-plugin",
+        "pluginName": "artifactory-artifact-manager",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/artifactory-artifact-manager-plugin/pull/128",
+        "description": "Hello artifactory-artifact-manager developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 217,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:03:15Z",
+        "updatedAt": "2025-08-09T09:15:41Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/oss-symbols-api-plugin",
+        "pluginName": "oss-symbols-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217",
+        "description": "Hello oss-symbols-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 78,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T09:01:19Z",
+        "updatedAt": "2025-08-09T09:15:34Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/mariadb-api-plugin",
+        "pluginName": "mariadb-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/mariadb-api-plugin/pull/78",
+        "description": "Hello mariadb-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 126,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:59:29Z",
+        "updatedAt": "2025-08-09T09:09:37Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jnr-posix-api-plugin",
+        "pluginName": "jnr-posix-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126",
+        "description": "Hello jnr-posix-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 94,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:57:36Z",
+        "updatedAt": "2025-08-09T09:04:23Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/json-path-api-plugin",
+        "pluginName": "json-path-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/json-path-api-plugin/pull/94",
+        "description": "Hello json-path-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 29,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:55:42Z",
+        "updatedAt": "2025-08-09T09:08:04Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/jsoup-plugin",
+        "pluginName": "jsoup",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/jsoup-plugin/pull/29",
+        "description": "Hello jsoup developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 86,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:53:53Z",
+        "updatedAt": "2025-08-09T09:07:57Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/json-api-plugin",
+        "pluginName": "json-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/json-api-plugin/pull/86",
+        "description": "Hello json-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 80,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:51:52Z",
+        "updatedAt": "2025-08-09T08:59:36Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/joda-time-api-plugin",
+        "pluginName": "joda-time-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/joda-time-api-plugin/pull/80",
+        "description": "Hello joda-time-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 87,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:49:58Z",
+        "updatedAt": "2025-08-09T09:08:18Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/gson-api-plugin",
+        "pluginName": "gson-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/gson-api-plugin/pull/87",
+        "description": "Hello gson-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 40,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:44:24Z",
+        "updatedAt": "2025-08-09T08:54:53Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/commons-math3-api-plugin",
+        "pluginName": "commons-math3-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/40",
+        "description": "Hello commons-math3-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 92,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:42:39Z",
+        "updatedAt": "2025-08-09T08:54:25Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/byte-buddy-api-plugin",
+        "pluginName": "byte-buddy-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/92",
+        "description": "Hello byte-buddy-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 91,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:40:57Z",
+        "updatedAt": "2025-08-09T08:54:14Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/asm-api-plugin",
+        "pluginName": "asm-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/asm-api-plugin/pull/91",
+        "description": "Hello asm-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      },
+      {
+        "number": 68,
+        "title": "Migrate plugins to Java 25 LTS",
+        "state": "MERGED",
+        "createdAt": "2025-08-09T08:39:14Z",
+        "updatedAt": "2025-08-09T08:49:58Z",
+        "user": "jonesbusy",
+        "repository": "jenkinsci/artifactory-client-api-plugin",
+        "pluginName": "artifactory-client-api",
+        "labels": [
+          "dependencies"
+        ],
+        "url": "https://github.com/jenkinsci/artifactory-client-api-plugin/pull/68",
+        "description": "Hello artifactory-client-api developers! 👋\nThis is an automated pull request created by the Jenkins Plugin Modernizer tool. The tool has applied the following recipes to modernize the plugin:\n\n    Migrate plugins to Java 25\n    io.jenkins.tools.pluginmodernizer.MigrateToJava25\n    Migrate plugins to Java 25 LTS.\n\nWhat's Changed?\nWe have introduced changes to improve the plugin's compatibility with Java 25 and align it with modern Jenkins development standards\n\nReplaced deprecated API calls with their current equivalents where a clear migration path exists.\nUpgrade build files to use Java 25 as the target/source.\nUpgrade plugins to versions that are compatible with Java 25.\nAdd Java 25 configuration in Jenkinsfile for testing on ci.jenkins.io.",
+        "checkStatus": "SUCCESS"
+      }
+    ]
+  }
+]

--- a/test-jdk-25.sh
+++ b/test-jdk-25.sh
@@ -189,24 +189,8 @@ compile_plugin() {
                 if [ -f "pom.xml" ]; then
                     # Ensure Maven's stdout and stderr are consistently captured in the per-plugin log
                     echo "Running Maven build for $plugin_name..." >>"$DEBUG_LOG"
-                    echo "Executing: timeout 10m mvn clean install -DskipTests" >>"$DEBUG_LOG"
-                    timeout 20m mvn clean install \
-                      -Dmaven.test.skip=true \
-                      -Dmaven.javadoc.skip=true \
-                      -Dspotbugs.skip=true \
-                      -Dcheckstyle.skip=true \
-                      -Dlicense.skip=true \
-                      -Daccess-modifier-checker.skip=true \
-                      -Dmaven.compiler.fork=false \
-                      -Dmaven.compiler.source=17 \
-                      -Dmaven.compiler.target=17 \
-                      -Dmaven.compiler.release=17 \
-                      -Dgroovy.source.level=17 \
-                      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-                      -Dlicense.disableCheck=true \
-                      -Dspotless.check.skip=true \
-                      -Dpmd.skip=true \
-                      -Dmaven.license.skip=true >"$plugin_log_file" 2>&1
+                    echo "Executing: timeout 20m mvn clean install -DskipTests" >>"$DEBUG_LOG"
+                    timeout 20m mvn clean install -DskipTests >"$plugin_log_file" 2>&1
                     maven_exit_code=$?
                     echo "Maven output for $plugin_name is in $plugin_log_file" >>"$DEBUG_LOG"
                     if [ $maven_exit_code -eq 124 ]; then


### PR DESCRIPTION
- Use `mvn clean install -DskipTests` instead of extensive skip/compile flags to reduce complexity and rely on defaults
- Correct log message to reflect 20m timeout (was 10m)
- Add monthly PR data files for 2025-07 and 2025-08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added August 2025 PR datasets, including a complete list, a filtered subset, and a grouped summary focused on Java 25 LTS migration activity.

- Chores
  - Refreshed the partial August dataset with an additional merged entry.
  - Simplified the JDK 25 test build to a single Maven command with a defined timeout, improving reliability and log clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->