### PR TITLE
Use GITHUB_TOKEN for checkout and Git in jdk-25 workflow

### DIFF
--- a/.github/workflows/test-jdk-25.yml
+++ b/.github/workflows/test-jdk-25.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run test-jdk-25.sh with keep-alive
         run: |
@@ -32,6 +34,10 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      
+      - name: Set up GitHub credentials
+        run: |
+          git config --global url."https://${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Create Pull Request if there are changes
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
- Pass token to actions/checkout and configure credential URL rewrite for authenticated GitHub operations
- Ensure CI can commit and push changes when creating PRs
- Update build-debug.log and jdk-25-build-results.csv with latest run outputs