### PR TITLE
Use CR_PAT for PR creation in JDK 25 workflow to fix perms

### DIFF
--- a/.github/workflows/test-jdk-25.yml
+++ b/.github/workflows/test-jdk-25.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create Pull Request if there are changes
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.CR_PAT }}
           commit-message: "chore: update results from test-jdk-25.sh"
           branch: test-jdk-25/update-results
           title: "Update results from test-jdk-25.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ google-credentials.json
 /.idea/zencoder-chat-index.xml
 /.idea/zencoder-chats-dedicated.xml
 /.idea/zencoder/chats/*.json
+jdk-25-build-results.csv.lock


### PR DESCRIPTION
Replace ${{ github.token }} with ${{ secrets.CR_PAT }} in the create-pull-request step so the action has sufficient permissions to push branches and open PRs reliably. This avoids limitations of the default GITHUB_TOKEN.