### PR TITLE
refactor: remove dead oauth2 code and fix build error

### DIFF
--- a/github-profile-tools/internal/cache/storage.go
+++ b/github-profile-tools/internal/cache/storage.go
@@ -236,7 +236,7 @@ func (fs *FileStorage) DeleteByPrefix(keyPrefix string) error {
 	}
 
 	// Update stats
-	fs.stats.TotalEntries -= int64(deletedCount)
+	fs.stats.TotalEntries -= deletedCount
 	if deletedCount > 0 {
 		log.Printf("Deleted %d cache entries matching prefix: %s", deletedCount, keyPrefix)
 	}

--- a/github-profile-tools/internal/github/client.go
+++ b/github-profile-tools/internal/github/client.go
@@ -581,13 +581,6 @@ func (c *Client) FetchRepositoryContents(ctx context.Context, owner, repo string
 			return fmt.Errorf("failed to create request: %w", err)
 		}
 
-		// Add authorization header if we have a token
-		if c.httpClient.Transport != nil {
-			if _, ok := c.httpClient.Transport.(*oauth2.Transport); ok {
-				// The oauth2 transport will automatically add the Authorization header
-			}
-		}
-
 		req.Header.Set("Accept", "application/vnd.github.v3+json")
 		req.Header.Set("User-Agent", "github-profile-tools/1.0")
 


### PR DESCRIPTION
## Summary
This PR addresses two code quality issues discovered during post-PR #193 cleanup:

1. **Removes dead oauth2 transport check** (closes #225)
   - Removed no-op code in `FetchRepositoryContents()` 
   - oauth2.Transport already handles authorization automatically
   - No functional change - purely cleanup

2. **Fixes type mismatch build error**
   - Fixed `int`/`int64` mismatch in `DeleteByPrefix()`
   - Removed unnecessary cast that was preventing builds
   - Discovered while testing the oauth2 cleanup

## Changes Made
- **github-profile-tools/internal/github/client.go**: Removed lines 584-589 (dead oauth2 check)
- **github-profile-tools/internal/cache/storage.go**: Removed unnecessary `int64()` cast on line 239

## Testing
- ✅ Project builds successfully
- ✅ Binary created and tested (9.5MB)
- ✅ No functional changes - both fixes are cleanup only

## Related Issues
- Closes #225 (dead oauth2 code)
- Bonus fix: storage.go build error (discovered during testing)
- Follow-up from PR #193 review by CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected type handling in cache deletion statistics to prevent potential data integrity issues.

* **Refactor**
  * Removed redundant authorization header management code; OAuth2 transport now handles authentication headers automatically, improving code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->