### PR TITLE
ci: use updatecli pipeline subcommand

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -35,7 +35,7 @@ jobs:
       # The "diff" command of Updatecli is used with the specified config and values files
       # The GitHub token is passed as an environment variable for authentication
       - name: Run Updatecli in Dry Run mode
-        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -44,6 +44,6 @@ jobs:
       # The GitHub token is passed as an environment variable for authentication
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/main'
-        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow calls the top-level `updatecli diff`/`updatecli apply` commands, which newer updatecli releases mark as deprecated in favour of `updatecli pipeline diff`/`updatecli pipeline apply`. They still work but print a deprecation warning on every run.

The `updatecli-action` step installs the latest updatecli binary and pins no version, so the `pipeline` subcommand is available. No functional change, just drops the warning.